### PR TITLE
[FEAT] 사용자 카테고리 생성 및 삭제

### DIFF
--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -18,6 +18,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     PAGE_LESS_NULL(HttpStatus.BAD_REQUEST, "PAGE4001", "Page는 0부터 입니다."),
     ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROOM4001", "룸이 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "카테고리가 없습니다."),
+    NOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTE4001", "노트가 없습니다."),
     AUTHORITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTHORITY4001", "권한이 없습니다."),
     AUTHORITY_TYPE_ERROR(HttpStatus.BAD_REQUEST, "AUTHORITY4002", "올바른 권한 형식을 입력하세요.")
     ;

--- a/src/main/java/com/main/writeRoom/controller/CategoryController.java
+++ b/src/main/java/com/main/writeRoom/controller/CategoryController.java
@@ -1,0 +1,31 @@
+package com.main.writeRoom.controller;
+
+import com.main.writeRoom.apiPayload.ApiResponse;
+import com.main.writeRoom.apiPayload.status.SuccessStatus;
+import com.main.writeRoom.converter.RoomConverter;
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.service.CategoryService.CategoryCommandService;
+import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
+import com.main.writeRoom.web.dto.room.RoomResponseDTO.RoomInfoResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categorys")
+@Slf4j
+public class CategoryController {
+    private final CategoryCommandService categoryCommandService;
+
+    @PostMapping("/create/{roomId}")
+    public ApiResponse<RoomInfoResult> createCategory(@PathVariable(name = "roomId")Long roomId, @RequestBody
+                                                      CategoryRequestDTO.CreateCategoryDTO request) {
+        Room room = categoryCommandService.createCategory(roomId, request);
+        return ApiResponse.of(SuccessStatus._OK, RoomConverter.toCreateRoomResultDTO(room));
+    }
+}

--- a/src/main/java/com/main/writeRoom/controller/CategoryController.java
+++ b/src/main/java/com/main/writeRoom/controller/CategoryController.java
@@ -1,12 +1,17 @@
 package com.main.writeRoom.controller;
 
 import com.main.writeRoom.apiPayload.ApiResponse;
+import com.main.writeRoom.apiPayload.code.ErrorReasonDTO;
 import com.main.writeRoom.apiPayload.status.SuccessStatus;
 import com.main.writeRoom.converter.RoomConverter;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.service.CategoryService.CategoryCommandService;
 import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
 import com.main.writeRoom.web.dto.room.RoomResponseDTO.RoomInfoResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
     private final CategoryCommandService categoryCommandService;
 
+    @Operation(summary = "사용자 카테고리 생성 API", description = "사용자 카테고리를 생성하는 API 이며, 카테고리 이름을 입력해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ROOM4001", description = "룸이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
     @PostMapping("/create/{roomId}")
     public ApiResponse<RoomInfoResult> createCategory(@PathVariable(name = "roomId")Long roomId, @RequestBody
                                                       CategoryRequestDTO.CreateCategoryDTO request) {

--- a/src/main/java/com/main/writeRoom/controller/CategoryController.java
+++ b/src/main/java/com/main/writeRoom/controller/CategoryController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,6 +38,23 @@ public class CategoryController {
     public ApiResponse<RoomInfoResult> createCategory(@PathVariable(name = "roomId")Long roomId, @RequestBody
                                                       CategoryRequestDTO.CreateCategoryDTO request) {
         Room room = categoryCommandService.createCategory(roomId, request);
+        return ApiResponse.of(SuccessStatus._OK, RoomConverter.toCreateRoomResultDTO(room));
+    }
+
+    @Operation(summary = "사용자 카테고리 삭제 API", description = "사용자 카테고리를 삭제하는 API 입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ROOM4001", description = "룸이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTE4001", description = "노트가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CATEGORY4001", description = "카테고리가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+
+    })
+    @DeleteMapping("/{roomId}/{categoryId}")
+    public ApiResponse<RoomInfoResult> deleteCategory(@PathVariable(name = "roomId")Long roomId, @PathVariable(name = "categoryId")Long categoryId) {
+        Room room = categoryCommandService.deleteCategory(roomId, categoryId);
         return ApiResponse.of(SuccessStatus._OK, RoomConverter.toCreateRoomResultDTO(room));
     }
 }

--- a/src/main/java/com/main/writeRoom/converter/CategoryConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/CategoryConverter.java
@@ -1,0 +1,14 @@
+package com.main.writeRoom.converter;
+
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
+
+public class CategoryConverter {
+    public static Category toCategory(CategoryRequestDTO.CreateCategoryDTO request, Room room) {
+        return Category.builder()
+                .name(request.getCategoryName())
+                .room(room)
+                .build();
+    }
+}

--- a/src/main/java/com/main/writeRoom/domain/Category.java
+++ b/src/main/java/com/main/writeRoom/domain/Category.java
@@ -1,12 +1,15 @@
 package com.main.writeRoom.domain;
 
 import com.main.writeRoom.domain.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,4 +30,7 @@ public class Category extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "room")
     private Room room;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
+    private List<Note> notes;
 }

--- a/src/main/java/com/main/writeRoom/domain/Note.java
+++ b/src/main/java/com/main/writeRoom/domain/Note.java
@@ -34,4 +34,8 @@ public class Note extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "room")
     private Room room;
+
+    @ManyToOne
+    @JoinColumn(name = "category")
+    private Category category;
 }

--- a/src/main/java/com/main/writeRoom/handler/CategoryHandler.java
+++ b/src/main/java/com/main/writeRoom/handler/CategoryHandler.java
@@ -1,0 +1,8 @@
+package com.main.writeRoom.handler;
+
+import com.main.writeRoom.apiPayload.code.BaseErrorCode;
+import com.main.writeRoom.apiPayload.handler.GeneralException;
+
+public class CategoryHandler extends GeneralException {
+    public CategoryHandler(BaseErrorCode errorCode) { super(errorCode);}
+}

--- a/src/main/java/com/main/writeRoom/handler/NoteHandler.java
+++ b/src/main/java/com/main/writeRoom/handler/NoteHandler.java
@@ -1,0 +1,8 @@
+package com.main.writeRoom.handler;
+
+import com.main.writeRoom.apiPayload.code.BaseErrorCode;
+import com.main.writeRoom.apiPayload.handler.GeneralException;
+
+public class NoteHandler extends GeneralException {
+    public NoteHandler(BaseErrorCode errorCode) { super(errorCode);}
+}

--- a/src/main/java/com/main/writeRoom/repository/CategoryRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.main.writeRoom.repository;
+
+import com.main.writeRoom.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/main/writeRoom/repository/NoteRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/NoteRepository.java
@@ -1,0 +1,10 @@
+package com.main.writeRoom.repository;
+
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Note;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+    List<Note> findAllByCategory(Category category);
+}

--- a/src/main/java/com/main/writeRoom/repository/NoteRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/NoteRepository.java
@@ -2,9 +2,10 @@ package com.main.writeRoom.repository;
 
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.Room;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
-    List<Note> findAllByCategory(Category category);
+    List<Note> findAllByCategoryAndRoom(Category category, Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandService.java
@@ -1,0 +1,8 @@
+package com.main.writeRoom.service.CategoryService;
+
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
+
+public interface CategoryCommandService {
+    Room createCategory(Long roomId, CategoryRequestDTO.CreateCategoryDTO request);
+}

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandService.java
@@ -5,4 +5,5 @@ import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
 
 public interface CategoryCommandService {
     Room createCategory(Long roomId, CategoryRequestDTO.CreateCategoryDTO request);
+    Room deleteCategory(Long roomId, Long categoryId);
 }

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
@@ -1,0 +1,28 @@
+package com.main.writeRoom.service.CategoryService;
+
+import com.main.writeRoom.converter.CategoryConverter;
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.repository.CategoryRepository;
+import com.main.writeRoom.service.RoomService.RoomQueryService;
+import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryCommandServiceImpl implements CategoryCommandService{
+    private final RoomQueryService roomQueryService;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Room createCategory(Long roomId, CategoryRequestDTO.CreateCategoryDTO request) {
+        Room room = roomQueryService.findRoom(roomId);
+
+        Category category = CategoryConverter.toCategory(request, room);
+        categoryRepository.save(category);
+        return room;
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
@@ -1,11 +1,16 @@
 package com.main.writeRoom.service.CategoryService;
 
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.converter.CategoryConverter;
 import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.handler.NoteHandler;
 import com.main.writeRoom.repository.CategoryRepository;
+import com.main.writeRoom.service.NoteService.NoteQueryService;
 import com.main.writeRoom.service.RoomService.RoomQueryService;
 import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CategoryCommandServiceImpl implements CategoryCommandService{
     private final RoomQueryService roomQueryService;
+    private final CategoryQueryService categoryQueryService;
+    private final NoteQueryService noteQueryService;
     private final CategoryRepository categoryRepository;
 
     @Transactional
@@ -23,6 +30,19 @@ public class CategoryCommandServiceImpl implements CategoryCommandService{
 
         Category category = CategoryConverter.toCategory(request, room);
         categoryRepository.save(category);
+        return room;
+    }
+
+    @Transactional
+    public Room deleteCategory(Long roomId, Long categoryId) {
+        Room room = roomQueryService.findRoom(roomId);
+        Category category = categoryQueryService.findCategory(categoryId);
+        List<Note> note = noteQueryService.findNoteForCategory(category);
+
+        if (note.isEmpty()) {
+            throw new NoteHandler(ErrorStatus.NOTE_NOT_FOUND);
+        }
+        categoryRepository.delete(category);
         return room;
     }
 }

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryCommandServiceImpl.java
@@ -1,12 +1,11 @@
 package com.main.writeRoom.service.CategoryService;
 
-import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.converter.CategoryConverter;
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
-import com.main.writeRoom.handler.NoteHandler;
 import com.main.writeRoom.repository.CategoryRepository;
+import com.main.writeRoom.repository.NoteRepository;
 import com.main.writeRoom.service.NoteService.NoteQueryService;
 import com.main.writeRoom.service.RoomService.RoomQueryService;
 import com.main.writeRoom.web.dto.category.CategoryRequestDTO;
@@ -23,6 +22,7 @@ public class CategoryCommandServiceImpl implements CategoryCommandService{
     private final CategoryQueryService categoryQueryService;
     private final NoteQueryService noteQueryService;
     private final CategoryRepository categoryRepository;
+    private final NoteRepository noteRepository;
 
     @Transactional
     public Room createCategory(Long roomId, CategoryRequestDTO.CreateCategoryDTO request) {
@@ -37,12 +37,14 @@ public class CategoryCommandServiceImpl implements CategoryCommandService{
     public Room deleteCategory(Long roomId, Long categoryId) {
         Room room = roomQueryService.findRoom(roomId);
         Category category = categoryQueryService.findCategory(categoryId);
-        List<Note> note = noteQueryService.findNoteForCategory(category);
+        List<Note> notes = noteQueryService.findNoteForCategory(category, room);
 
-        if (note.isEmpty()) {
-            throw new NoteHandler(ErrorStatus.NOTE_NOT_FOUND);
+        if (!notes.isEmpty()) {
+            noteRepository.deleteAll(notes);
+            categoryRepository.delete(category);
+        } else {
+            categoryRepository.delete(category);
         }
-        categoryRepository.delete(category);
         return room;
     }
 }

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryQueryService.java
@@ -1,0 +1,7 @@
+package com.main.writeRoom.service.CategoryService;
+
+import com.main.writeRoom.domain.Category;
+
+public interface CategoryQueryService {
+    Category findCategory(Long categoryId);
+}

--- a/src/main/java/com/main/writeRoom/service/CategoryService/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/CategoryService/CategoryQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.main.writeRoom.service.CategoryService;
+
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.handler.CategoryHandler;
+import com.main.writeRoom.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryQueryServiceImpl implements CategoryQueryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public Category findCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
@@ -1,0 +1,9 @@
+package com.main.writeRoom.service.NoteService;
+
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Note;
+import java.util.List;
+
+public interface NoteQueryService {
+    List<Note> findNoteForCategory(Category category);
+}

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
@@ -2,8 +2,9 @@ package com.main.writeRoom.service.NoteService;
 
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.Room;
 import java.util.List;
 
 public interface NoteQueryService {
-    List<Note> findNoteForCategory(Category category);
+    List<Note> findNoteForCategory(Category category, Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.main.writeRoom.service.NoteService;
 
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.repository.NoteRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NoteQueryServiceImpl implements NoteQueryService{
     private final NoteRepository noteRepository;
 
-    public List<Note> findNoteForCategory(Category category) {
-        return noteRepository.findAllByCategory(category);
+    public List<Note> findNoteForCategory(Category category, Room room) {
+        return noteRepository.findAllByCategoryAndRoom(category, room);
     }
 }

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.main.writeRoom.service.NoteService;
+
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.repository.NoteRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoteQueryServiceImpl implements NoteQueryService{
+    private final NoteRepository noteRepository;
+
+    public List<Note> findNoteForCategory(Category category) {
+        return noteRepository.findAllByCategory(category);
+    }
+}

--- a/src/main/java/com/main/writeRoom/web/dto/category/CategoryRequestDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/category/CategoryRequestDTO.java
@@ -1,0 +1,13 @@
+package com.main.writeRoom.web.dto.category;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class CategoryRequestDTO {
+
+    @Getter
+    public static class CreateCategoryDTO {
+        @NotBlank
+        String categoryName;
+    }
+}


### PR DESCRIPTION
## 이슈
- https://github.com/WRITE-ROOM/SERVER/issues/23

<br>

## 작업 내용
- 사용자 카테고리 생성
- 사용자 카테고리 삭제

<br>

## 참고 사항
사용자 카테고리 삭제에서 카테고리에 속한 노트 전부 삭제로 구현했습니다.
노트 글 쓰기 할 때 새로운 카테고리를 지정하는 경우 카테고리 테이블에 추가되도록 구현해주세요!
