### PR TITLE
[FEAT] 나의 챌린지 관련 API 구현

### DIFF
--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -28,7 +28,9 @@ public enum ErrorStatus implements BaseErrorCode {
     PROGRESS_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4002", "진행 중인 챌린지가 없습니다."),
     STARTDATE_NOT_TODAY(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "챌린지 시작 날짜가 오늘부터여야 합니다."),
     DEADLINE_OUT_RANGE(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "챌린지 마감 날짜 범위를 벗어났습니다."),
-    GOALS_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "챌린지 목표량이 없습니다.")
+    GOALS_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "챌린지 목표량이 없습니다."),
+    NOT_PARTICIPATE(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "해당 챌린지에 사용자가 참여하지 않았습니다."),
+    CHALLENGE_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "룸과 회원에 해당하는 챌린지가 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -84,12 +84,15 @@ public class ChallengeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4001", description = "챌린지 루틴이 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4004", description = "챌린지 마감 날짜 범위를 벗어났습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4002", description = "진행 중인 챌린지가 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class)))
     })
     @Parameters
     public ApiResponse<ChallengeResponseDTO.ChallengeRoutineDTO> getChallengeRoutine(@PathVariable(name = "userId") Long userId, @PathVariable(name = "challengeId") Long challengeId) {
         User user = userQueryService.findUser(userId);
         ChallengeRoutine routine = routineQueryService.findRoutine(challengeId);
+        routineCommandService.isStatusProgress(user, routine);
         List<ChallengeResponseDTO.NoteDTO> noteList = routineQueryService.findNoteDate(user, routine);
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeRoutineDTO(user, routine, noteList));
     }
@@ -167,6 +170,7 @@ public class ChallengeController {
     public ApiResponse<ChallengeResponseDTO.ChallengeGoalsDTO> getChallengeGoals(@PathVariable(name = "userId") Long userId, @PathVariable(name = "challengeId") Long challengeId) {
         User user = userQueryService.findUser(userId);
         ChallengeGoals goals = goalsQueryService.findGoals(challengeId);
+        goalsCommandService.isStatusProgress(user, goals);
         Integer achieveCount = goalsQueryService.findAchieveNote(user, goals);
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user, goals, achieveCount));
     }

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -107,9 +107,9 @@ public class ChallengeController {
     @Parameters({
             @Parameter(name = "userId", description = "챌린지를 포기할 회원의 식별자를 입력하세요."),
     })
-    public ApiResponse<ChallengeResponseDTO.GiveUpChallengeResultDTO> giveUpChallengeRoutine(@PathVariable(name = "challengeId") Long challengeId, @RequestParam Long userId) {
+    public ApiResponse giveUpChallengeRoutine(@PathVariable(name = "challengeId") Long challengeId, @RequestParam Long userId) {
         ChallengeRoutineParticipation routineParticipation = routineCommandService.giveUp(userId, challengeId);
-        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toGiveUpChallengeRoutineResultDTO(routineParticipation));
+        return ApiResponse.onSuccess();
     }
 
     //챌린지 목표량
@@ -166,9 +166,9 @@ public class ChallengeController {
     @Parameters({
             @Parameter(name = "userId", description = "챌린지를 포기할 회원의 식별자를 입력하세요."),
     })
-    public ApiResponse<ChallengeResponseDTO.GiveUpChallengeResultDTO> giveUpChallengeGoals(@PathVariable(name = "challengeId") Long challengeId, @RequestParam Long userId) {
+    public ApiResponse giveUpChallengeGoals(@PathVariable(name = "challengeId") Long challengeId, @RequestParam Long userId) {
         ChallengeGoalsParticipation goalsParticipation = goalsCommandService.giveUP(userId, challengeId);
-        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toGiveUpChallengeGoalsResultDTO(goalsParticipation));
+        return ApiResponse.onSuccess();
     }
 
     //나의 챌린지

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -130,8 +130,9 @@ public class ChallengeConverter {
     //나의 챌린지
     //나의 챌린지 이력 조회
     public static ChallengeResponseDTO.MyChallengeDTO toMyChallengeDTO(ChallengeRoutine routine, ChallengeRoutineParticipation routineParticipation) {
-        List<ChallengeResponseDTO.UserDTO> participantList = routine.getParticipantList().stream()
-                .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
+        List<ChallengeResponseDTO.UserDTO> participantList = routine.getChallengeRoutineParticipationList().stream()
+                .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
+                .map(participant -> ChallengeConverter.toUserDTO(participant.getUser())).collect(Collectors.toList());
 
         LocalDate endDate;
         if (routineParticipation.getChallengeStatus() == ChallengeStatus.GIVEUP) {
@@ -149,8 +150,9 @@ public class ChallengeConverter {
     }
 
     public static ChallengeResponseDTO.MyChallengeDTO toMyChallengeDTO(ChallengeGoals goals, ChallengeGoalsParticipation goalsParticipation) {
-        List<ChallengeResponseDTO.UserDTO> participantList = goals.getParticipantList().stream()
-                    .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
+        List<ChallengeResponseDTO.UserDTO> participantList = goals.getChallengeGoalsParticipationList().stream()
+                    .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
+                    .map(participant -> ChallengeConverter.toUserDTO(participant.getUser())).collect(Collectors.toList());
 
         LocalDate endDate;
         if (goalsParticipation.getChallengeStatus() == ChallengeStatus.GIVEUP) {
@@ -178,7 +180,7 @@ public class ChallengeConverter {
     //나의 챌린지 상세 조회 - 루틴
     public static ChallengeResponseDTO.MyChallengeRoutineDTO toMyChallengeRoutineDTO(User user, ChallengeRoutine routine, List<ChallengeResponseDTO.NoteDTO> noteList, ChallengeRoutineParticipation routineParticipation)  {
         List<ChallengeResponseDTO.UserDTO> userList = routine.getChallengeRoutineParticipationList().stream()
-                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.SUCCESS) || (participation.getChallengeStatus() == ChallengeStatus.FAILURE))
+                .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
                     return ChallengeConverter.toUserDTO(participation.getUser());
                 }).collect(Collectors.toList());
@@ -198,7 +200,7 @@ public class ChallengeConverter {
     //나의 챌린지 상세 조회 - 목표량
     public static ChallengeResponseDTO.MyChallengeGoalsDTO toMyChallengeGoalsDTO(User user, ChallengeGoals goals, Integer achieveCount, ChallengeGoalsParticipation goalsParticipation)  {
         List<ChallengeResponseDTO.UserDTO> userList = goals.getChallengeGoalsParticipationList().stream()
-                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.SUCCESS) || (participation.getChallengeStatus() == ChallengeStatus.FAILURE))
+                .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
                     return ChallengeConverter.toUserDTO(participation.getUser());
                 }).collect(Collectors.toList());

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -39,7 +39,6 @@ public class ChallengeConverter {
     public static ChallengeResponseDTO.CreateChallengeResultDTO toCreateChallengeRoutineResultDTO(ChallengeRoutine challengeRoutine) {
         return ChallengeResponseDTO.CreateChallengeResultDTO.builder()
                 .challengeId(challengeRoutine.getId())
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 
@@ -52,6 +51,7 @@ public class ChallengeConverter {
                 }).collect(Collectors.toList());
 
         return ChallengeResponseDTO.ChallengeRoutineDTO.builder()
+                .challengeId(routine.getId())
                 .userName(user.getName())
                 .startDate(routine.getStartDate())
                 .deadline(routine.getDeadline())
@@ -104,7 +104,6 @@ public class ChallengeConverter {
     public static ChallengeResponseDTO.CreateChallengeResultDTO toCreateChallengeGoalsResultDTO(ChallengeGoals challengeGoals) {
         return ChallengeResponseDTO.CreateChallengeResultDTO.builder()
                 .challengeId(challengeGoals.getId())
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 
@@ -117,6 +116,7 @@ public class ChallengeConverter {
                 }).collect(Collectors.toList());
 
         return ChallengeResponseDTO.ChallengeGoalsDTO.builder()
+                .challengeId(goals.getId())
                 .userName(user.getName())
                 .startDate(goals.getStartDate())
                 .deadline(goals.getDeadline())
@@ -140,6 +140,7 @@ public class ChallengeConverter {
         else endDate = routine.getDeadline();
 
         return ChallengeResponseDTO.MyChallengeDTO.builder()
+                .challengeId(routine.getId())
                 .challengeName(routine.toString())
                 .participantList(participantList)
                 .status(routineParticipation.getChallengeStatus())
@@ -158,6 +159,7 @@ public class ChallengeConverter {
         else endDate = goals.getDeadline();
 
         return ChallengeResponseDTO.MyChallengeDTO.builder()
+                .challengeId(goals.getId())
                 .challengeName(goals.toString())
                 .participantList(participantList)
                 .status(goalsParticipation.getChallengeStatus())
@@ -182,6 +184,7 @@ public class ChallengeConverter {
                 }).collect(Collectors.toList());
 
         return ChallengeResponseDTO.MyChallengeRoutineDTO.builder()
+                .challengeId(routine.getId())
                 .userName(user.getName())
                 .startDate(routine.getStartDate())
                 .deadline(routine.getDeadline())
@@ -201,6 +204,7 @@ public class ChallengeConverter {
                 }).collect(Collectors.toList());
 
         return ChallengeResponseDTO.MyChallengeGoalsDTO.builder()
+                .challengeId(goals.getId())
                 .userName(user.getName())
                 .startDate(goals.getStartDate())
                 .deadline(goals.getDeadline())

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -10,7 +10,7 @@ import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -128,4 +128,59 @@ public class ChallengeConverter {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
+    //나의 챌린지
+    //나의 챌린지 이력 조회
+    public static ChallengeResponseDTO.MyChallengeDTO toMyChallengeDTO(ChallengeRoutine routine, ChallengeRoutineParticipation routineParticipation) {
+        List<ChallengeResponseDTO.UserDTO> participantList = routine.getParticipantList().stream()
+                .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
+
+        return ChallengeResponseDTO.MyChallengeDTO.builder()
+                .challengeName(routine.toString())
+                .participantList(participantList)
+                .status(routineParticipation.getChallengeStatus())
+                .endDate(routineParticipation.getStatusUpdatedAt())
+                .build();
+    }
+
+    public static ChallengeResponseDTO.MyChallengeDTO toMyChallengeDTO(ChallengeGoals goals, ChallengeGoalsParticipation goalsParticipation) {
+        List<ChallengeResponseDTO.UserDTO> participantList = goals.getParticipantList().stream()
+                    .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
+
+        return ChallengeResponseDTO.MyChallengeDTO.builder()
+                    .challengeName(goals.toString())
+                .participantList(participantList)
+                .status(goalsParticipation.getChallengeStatus())
+                .endDate(goalsParticipation.getStatusUpdatedAt())
+                .build();
+    }
+
+    public static ChallengeResponseDTO.MyChallengeListDTO toMyChallengeDTOList(List<ChallengeResponseDTO.MyChallengeDTO> myRoutineList,List<ChallengeResponseDTO.MyChallengeDTO> myGoalsList) {
+
+        return ChallengeResponseDTO.MyChallengeListDTO.builder()
+                .myChallengeRoutineDTOList(myRoutineList)
+                .myChallengeGoalsDTOList(myGoalsList)
+                .build();
+    }
+
+    /*public static List<ChallengeResponseDTO.MyChallengeDTO> test(List<ChallengeResponseDTO.GetMyChallengeDTO> getMyChallengeDTOS) {
+
+        List<ChallengeResponseDTO.MyChallengeDTO> myChallengeDTOList = new ArrayList<>();
+        for (int i = 0; i < getMyChallengeDTOS.size(); i++) {
+            myChallengeDTOList.add(ChallengeResponseDTO.MyChallengeDTO.builder()
+                            .endDate(getMyChallengeDTOS.get(i).getEndDate())
+                            .participantList(getMyChallengeDTOS.get(i).getParticipantList().stream().map(participation -> {
+                                return ChallengeResponseDTO.UserDTO.builder()
+                                        .userName(participation.getUser().getName())
+                                        .profileImage(participation.getUser().getProfileImage())
+                                        .userId(participation.getUser().getId())
+                                        .build();
+                            }).collect(Collectors.toList()))
+                            .challengeName(getMyChallengeDTOS.get(i).toString())
+                            .status(getMyChallengeDTOS.get(i).getStatus())
+                            .build());
+        }
+
+        return myChallengeDTOList;
+    }*/
 }

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -46,7 +46,7 @@ public class ChallengeConverter {
     //2. 챌린지 루틴 조회
     public static ChallengeResponseDTO.ChallengeRoutineDTO toChallengeRoutineDTO(User user, ChallengeRoutine routine, List<ChallengeResponseDTO.NoteDTO> noteList)  {
         List<ChallengeResponseDTO.UserDTO> userList = routine.getChallengeRoutineParticipationList().stream()
-                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.PROGRESS) || (participation.getChallengeStatus() == ChallengeStatus.SUCCESS))
+                .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
                         return ChallengeConverter.toUserDTO(participation.getUser());
                 }).collect(Collectors.toList());
@@ -111,7 +111,7 @@ public class ChallengeConverter {
     //챌린지 목표량 조회
     public static ChallengeResponseDTO.ChallengeGoalsDTO toChallengeGoalsDTO(User user, ChallengeGoals goals, Integer achieveCount)  {
         List<ChallengeResponseDTO.UserDTO> userList = goals.getChallengeGoalsParticipationList().stream()
-                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.PROGRESS) || (participation.getChallengeStatus() == ChallengeStatus.SUCCESS))
+                .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
                     return ChallengeConverter.toUserDTO(participation.getUser());
                 }).collect(Collectors.toList());
@@ -133,11 +133,17 @@ public class ChallengeConverter {
         List<ChallengeResponseDTO.UserDTO> participantList = routine.getParticipantList().stream()
                 .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
 
+        LocalDate endDate;
+        if (routineParticipation.getChallengeStatus() == ChallengeStatus.GIVEUP) {
+            endDate = routineParticipation.getStatusUpdatedAt();
+        }
+        else endDate = routine.getDeadline();
+
         return ChallengeResponseDTO.MyChallengeDTO.builder()
                 .challengeName(routine.toString())
                 .participantList(participantList)
                 .status(routineParticipation.getChallengeStatus())
-                .endDate(routineParticipation.getStatusUpdatedAt())
+                .endDate(endDate)
                 .build();
     }
 
@@ -145,11 +151,17 @@ public class ChallengeConverter {
         List<ChallengeResponseDTO.UserDTO> participantList = goals.getParticipantList().stream()
                     .map(participant -> ChallengeConverter.toUserDTO(participant)).collect(Collectors.toList());
 
+        LocalDate endDate;
+        if (goalsParticipation.getChallengeStatus() == ChallengeStatus.GIVEUP) {
+            endDate = goalsParticipation.getStatusUpdatedAt();
+        }
+        else endDate = goals.getDeadline();
+
         return ChallengeResponseDTO.MyChallengeDTO.builder()
-                    .challengeName(goals.toString())
+                .challengeName(goals.toString())
                 .participantList(participantList)
                 .status(goalsParticipation.getChallengeStatus())
-                .endDate(goalsParticipation.getStatusUpdatedAt())
+                .endDate(endDate)
                 .build();
     }
 

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -8,14 +8,17 @@ import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
+import com.main.writeRoom.repository.ChallengeRoutineParticipationRepository;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 public class ChallengeConverter {
 
     //1. 챌린지 루틴 생성
@@ -163,24 +166,22 @@ public class ChallengeConverter {
                 .build();
     }
 
-    /*public static List<ChallengeResponseDTO.MyChallengeDTO> test(List<ChallengeResponseDTO.GetMyChallengeDTO> getMyChallengeDTOS) {
+    //나의 챌린지 상세 조회 - 루틴
+    public static ChallengeResponseDTO.MyChallengeRoutineDTO toMyChallengeRoutineDTO(User user, ChallengeRoutine routine, List<ChallengeResponseDTO.NoteDTO> noteList, ChallengeRoutineParticipation routineParticipation)  {
+        List<ChallengeResponseDTO.UserDTO> userList = routine.getChallengeRoutineParticipationList().stream()
+                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.SUCCESS) || (participation.getChallengeStatus() == ChallengeStatus.FAILURE))
+                .map(participation -> {
+                    return ChallengeConverter.toUserDTO(participation.getUser());
+                }).collect(Collectors.toList());
 
-        List<ChallengeResponseDTO.MyChallengeDTO> myChallengeDTOList = new ArrayList<>();
-        for (int i = 0; i < getMyChallengeDTOS.size(); i++) {
-            myChallengeDTOList.add(ChallengeResponseDTO.MyChallengeDTO.builder()
-                            .endDate(getMyChallengeDTOS.get(i).getEndDate())
-                            .participantList(getMyChallengeDTOS.get(i).getParticipantList().stream().map(participation -> {
-                                return ChallengeResponseDTO.UserDTO.builder()
-                                        .userName(participation.getUser().getName())
-                                        .profileImage(participation.getUser().getProfileImage())
-                                        .userId(participation.getUser().getId())
-                                        .build();
-                            }).collect(Collectors.toList()))
-                            .challengeName(getMyChallengeDTOS.get(i).toString())
-                            .status(getMyChallengeDTOS.get(i).getStatus())
-                            .build());
-        }
-
-        return myChallengeDTOList;
-    }*/
+        return ChallengeResponseDTO.MyChallengeRoutineDTO.builder()
+                .userName(user.getName())
+                .startDate(routine.getStartDate())
+                .deadline(routine.getDeadline())
+                .targetCount(routine.getTargetCount())
+                .userList(userList)
+                .noteList(noteList)
+                .challengeStatus(routineParticipation.getChallengeStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -1,5 +1,6 @@
 package com.main.writeRoom.converter;
 
+import com.main.writeRoom.domain.ACHIEVE;
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
 import com.main.writeRoom.domain.Note;
@@ -11,8 +12,11 @@ import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import com.main.writeRoom.repository.ChallengeRoutineParticipationRepository;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
+import com.main.writeRoom.web.dto.note.NoteResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +76,18 @@ public class ChallengeConverter {
                 .build();
     }
 
+    //챌린지 루틴 해당 날짜의 200자 이상 노트 목록 조회
+    public static ChallengeResponseDTO.RoomResultByDate toRoomResultByDate(Room room, Page<Note> notes, LocalDate date) {
+        List<NoteResponseDTO.NoteList> toRoomResultNoteDTOList = notes.stream()
+                .filter(note -> note.getCreatedAt().toLocalDate().isEqual(date))
+                .filter(note -> note.getAchieve() == ACHIEVE.TRUE)
+                .map(NoteConverter::toRoomResultNoteDTOList).collect(Collectors.toList());
+
+        return ChallengeResponseDTO.RoomResultByDate.builder()
+                .roomId(room.getId())
+                .noteList(toRoomResultNoteDTOList)
+                .build();
+    }
 
     //챌린지 목표량
     //챌린지 목표량 생성

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -72,16 +72,6 @@ public class ChallengeConverter {
                 .build();
     }
 
-    //5. 챌린지 루틴 포기
-    public static ChallengeResponseDTO.GiveUpChallengeResultDTO toGiveUpChallengeRoutineResultDTO(ChallengeRoutineParticipation routineParticipation) {
-
-        return ChallengeResponseDTO.GiveUpChallengeResultDTO.builder()
-                .userId(routineParticipation.getUser().getId())
-                .challengeId(routineParticipation.getChallengeRoutine().getId())
-                .status(routineParticipation.getChallengeStatus())
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
 
     //챌린지 목표량
     //챌린지 목표량 생성
@@ -120,17 +110,6 @@ public class ChallengeConverter {
                 .build();
     }
 
-
-    //챌린지 목표량 포기
-    public static ChallengeResponseDTO.GiveUpChallengeResultDTO toGiveUpChallengeGoalsResultDTO(ChallengeGoalsParticipation goalsParticipation) {
-
-        return ChallengeResponseDTO.GiveUpChallengeResultDTO.builder()
-                .userId(goalsParticipation.getUser().getId())
-                .challengeId(goalsParticipation.getChallengeGoals().getId())
-                .status(goalsParticipation.getChallengeStatus())
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
 
     //나의 챌린지
     //나의 챌린지 이력 조회

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -184,4 +184,23 @@ public class ChallengeConverter {
                 .challengeStatus(routineParticipation.getChallengeStatus())
                 .build();
     }
+
+    //나의 챌린지 상세 조회 - 목표량
+    public static ChallengeResponseDTO.MyChallengeGoalsDTO toMyChallengeGoalsDTO(User user, ChallengeGoals goals, Integer achieveCount, ChallengeGoalsParticipation goalsParticipation)  {
+        List<ChallengeResponseDTO.UserDTO> userList = goals.getChallengeGoalsParticipationList().stream()
+                .filter(participation -> (participation.getChallengeStatus() == ChallengeStatus.SUCCESS) || (participation.getChallengeStatus() == ChallengeStatus.FAILURE))
+                .map(participation -> {
+                    return ChallengeConverter.toUserDTO(participation.getUser());
+                }).collect(Collectors.toList());
+
+        return ChallengeResponseDTO.MyChallengeGoalsDTO.builder()
+                .userName(user.getName())
+                .startDate(goals.getStartDate())
+                .deadline(goals.getDeadline())
+                .targetCount(goals.getTargetCount())
+                .userList(userList)
+                .achieveCount(achieveCount)
+                .challengeStatus(goalsParticipation.getChallengeStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/main/writeRoom/domain/Challenge/ChallengeGoals.java
+++ b/src/main/java/com/main/writeRoom/domain/Challenge/ChallengeGoals.java
@@ -1,6 +1,7 @@
 package com.main.writeRoom.domain.Challenge;
 
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.common.BaseEntity;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import jakarta.persistence.*;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,4 +37,15 @@ public class ChallengeGoals extends BaseEntity {
 
     @OneToMany(mappedBy = "challengeGoals")
     private List<ChallengeGoalsParticipation> challengeGoalsParticipationList = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return targetCount+"개 글쓰기";
+    }
+
+    public List<User> getParticipantList() { //챌린지 루틴과 목표량의 참여 타입을 User로 통일해야해서 만듦.
+        return challengeGoalsParticipationList.stream()
+                .map(ChallengeGoalsParticipation::getUser)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/main/writeRoom/domain/Challenge/ChallengeRoutine.java
+++ b/src/main/java/com/main/writeRoom/domain/Challenge/ChallengeRoutine.java
@@ -1,6 +1,7 @@
 package com.main.writeRoom.domain.Challenge;
 
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.common.BaseEntity;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import jakarta.persistence.*;
@@ -8,6 +9,7 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ChallengeRoutine extends BaseEntity {
+public class ChallengeRoutine extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,4 +38,14 @@ public class ChallengeRoutine extends BaseEntity {
     @OneToMany(mappedBy = "challengeRoutine")
     private List<ChallengeRoutineParticipation> challengeRoutineParticipationList = new ArrayList<>();
 
+    @Override
+    public String toString() {
+        return "일주일에 " + targetCount + "일 글쓰기";
+    }
+
+    public List<User> getParticipantList() {
+        return challengeRoutineParticipationList.stream()
+                .map(ChallengeRoutineParticipation::getUser)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/ChallengeGoalsParticipation.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/ChallengeGoalsParticipation.java
@@ -2,9 +2,13 @@ package com.main.writeRoom.domain.mapping;
 
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -20,6 +24,8 @@ public class ChallengeGoalsParticipation {
     @Enumerated(EnumType.STRING)
     private ChallengeStatus challengeStatus;
 
+    private LocalDate statusUpdatedAt; //나의 챌린지에서 endDate를 위한 필드
+
     @ManyToOne
     @JoinColumn(name = "user")
     private User user;
@@ -27,6 +33,10 @@ public class ChallengeGoalsParticipation {
     @ManyToOne
     @JoinColumn(name = "challenge_goals")
     private ChallengeGoals challengeGoals;
+
+    @ManyToOne
+    @JoinColumn(name = "room")
+    private Room room;
 
     public void setChallengeGoals(ChallengeGoals challengeGoals) {
         if (this.challengeGoals != null)
@@ -41,5 +51,13 @@ public class ChallengeGoalsParticipation {
 
     public void setChallengeStatus(ChallengeStatus challengeStatus) {
         this.challengeStatus = challengeStatus;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public void setStatusUpdatedAt(LocalDate localDate) {
+        this.statusUpdatedAt = localDate;
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/ChallengeGoalsParticipation.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/ChallengeGoalsParticipation.java
@@ -6,6 +6,9 @@ import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,6 +18,8 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
 public class ChallengeGoalsParticipation {
 
     @Id
@@ -25,6 +30,10 @@ public class ChallengeGoalsParticipation {
     private ChallengeStatus challengeStatus;
 
     private LocalDate statusUpdatedAt; //나의 챌린지에서 endDate를 위한 필드
+
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ACTIVE'")
+    private IsActive isActive;  //나의 챌린지에서 내역 삭제를 하면 비활성화가 되어 내역에서 안보인다. 내역에선 안뜨고, 다른 회원이 봤을 땐 참여자로 떠야하기 때문. -> 참여자 모두 포기한 상태면 db에서 챌린지 참여와 챌린지 삭제
 
     @ManyToOne
     @JoinColumn(name = "user")
@@ -59,5 +68,9 @@ public class ChallengeGoalsParticipation {
 
     public void setStatusUpdatedAt(LocalDate localDate) {
         this.statusUpdatedAt = localDate;
+    }
+
+    public void setIsActive(IsActive isActive) {
+        this.isActive = isActive;
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/ChallengeRoutineParticipation.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/ChallengeRoutineParticipation.java
@@ -1,9 +1,13 @@
 package com.main.writeRoom.domain.mapping;
 
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,6 +23,8 @@ public class ChallengeRoutineParticipation {
     @Enumerated(EnumType.STRING)
     private ChallengeStatus challengeStatus;
 
+    private LocalDate statusUpdatedAt;
+
     @ManyToOne
     @JoinColumn(name = "user")
     private User user;
@@ -26,6 +32,10 @@ public class ChallengeRoutineParticipation {
     @ManyToOne
     @JoinColumn(name = "challenge_routine")
     private ChallengeRoutine challengeRoutine;
+
+    @ManyToOne
+    @JoinColumn(name = "room")
+    private Room room;
 
     public void setChallengeRoutine(ChallengeRoutine challengeRoutine) {
         if (this.challengeRoutine != null)
@@ -40,5 +50,13 @@ public class ChallengeRoutineParticipation {
 
     public void setChallengeStatus(ChallengeStatus challengeStatus) {
         this.challengeStatus = challengeStatus;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public void setStatusUpdatedAt(LocalDate localDate) {
+        this.statusUpdatedAt = localDate;
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/ChallengeRoutineParticipation.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/ChallengeRoutineParticipation.java
@@ -5,6 +5,9 @@ import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +17,8 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
 public class ChallengeRoutineParticipation {
 
     @Id
@@ -24,6 +29,10 @@ public class ChallengeRoutineParticipation {
     private ChallengeStatus challengeStatus;
 
     private LocalDate statusUpdatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ACTIVE'")
+    private IsActive isActive;
 
     @ManyToOne
     @JoinColumn(name = "user")
@@ -58,5 +67,9 @@ public class ChallengeRoutineParticipation {
 
     public void setStatusUpdatedAt(LocalDate localDate) {
         this.statusUpdatedAt = localDate;
+    }
+
+    public void setIsActive(IsActive isActive) {
+        this.isActive = isActive;
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/ChallengeStatus.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/ChallengeStatus.java
@@ -1,5 +1,5 @@
 package com.main.writeRoom.domain.mapping;
 
 public enum ChallengeStatus {
-    PROGRESS, SUCCESS, FAILURE
+    PROGRESS, SUCCESS, FAILURE, GIVEUP
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/IsActive.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/IsActive.java
@@ -1,0 +1,5 @@
+package com.main.writeRoom.domain.mapping;
+
+public enum IsActive {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/main/writeRoom/repository/ChallengeGoalsParticipationRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/ChallengeGoalsParticipationRepository.java
@@ -18,4 +18,6 @@ public interface ChallengeGoalsParticipationRepository extends JpaRepository<Cha
     public ChallengeGoalsParticipation findByUserAndChallengeGoals(User user, ChallengeGoals goals);
 
     public List<ChallengeGoalsParticipation> findByUserAndRoom(User user, Room room);
+
+    public List<ChallengeGoalsParticipation> findByChallengeGoals(ChallengeGoals goals);
 }

--- a/src/main/java/com/main/writeRoom/repository/ChallengeGoalsParticipationRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/ChallengeGoalsParticipationRepository.java
@@ -1,10 +1,21 @@
 package com.main.writeRoom.repository;
 
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeStatus;
+import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
 
 public interface ChallengeGoalsParticipationRepository extends JpaRepository<ChallengeGoalsParticipation, Long> {
     public ChallengeGoalsParticipation findByUserAndChallengeGoals(User user, ChallengeGoals goals);
+
+    public List<ChallengeGoalsParticipation> findByUserAndRoom(User user, Room room);
 }

--- a/src/main/java/com/main/writeRoom/repository/ChallengeRoutineParticipationRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/ChallengeRoutineParticipationRepository.java
@@ -16,4 +16,6 @@ public interface ChallengeRoutineParticipationRepository extends JpaRepository<C
     public ChallengeRoutineParticipation findByUserAndChallengeRoutine(User user, ChallengeRoutine routine);
 
     public List<ChallengeRoutineParticipation> findByUserAndRoom(User user, Room room);
+
+    public List<ChallengeRoutineParticipation> findByChallengeRoutine(ChallengeRoutine routine);
 }

--- a/src/main/java/com/main/writeRoom/repository/ChallengeRoutineParticipationRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/ChallengeRoutineParticipationRepository.java
@@ -1,10 +1,19 @@
 package com.main.writeRoom.repository;
 
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public interface ChallengeRoutineParticipationRepository extends JpaRepository<ChallengeRoutineParticipation, Long> {
-    ChallengeRoutineParticipation findByUserAndChallengeRoutine(User user, ChallengeRoutine routine);
+    public ChallengeRoutineParticipation findByUserAndChallengeRoutine(User user, ChallengeRoutine routine);
+
+    public List<ChallengeRoutineParticipation> findByUserAndRoom(User user, Room room);
 }

--- a/src/main/java/com/main/writeRoom/repository/NoteRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/NoteRepository.java
@@ -31,4 +31,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 
     Page<Note> findAllByRoom(Room room, PageRequest pageRequest);
     Long countByRoom(Room room);
+
+    Page<Note> findAllByRoomAndUser(Room room, User user, PageRequest pageRequest);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandService.java
@@ -1,6 +1,8 @@
 package com.main.writeRoom.service.ChallengeService;
 
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 
@@ -10,4 +12,5 @@ public interface ChallengeGoalsCommandService {
     public ChallengeGoals create(Long roomId, ChallengeRequestDTO.ChallengeGoalsDTO request);
     public void deadlineRangeNull(LocalDate startDate, LocalDate deadline);
     public ChallengeGoalsParticipation giveUP(Long userId, Long challengeGoalsId);
+    public void isStatusProgress(User user, ChallengeGoals goals);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
@@ -82,8 +82,8 @@ public class ChallengeGoalsCommandServiceImpl implements ChallengeGoalsCommandSe
         //회원과 챌린지로 챌린지 참여 조회
         ChallengeGoalsParticipation goalsParticipation = goalsParticipationRepository.findByUserAndChallengeGoals(user, goals);
         if (goalsParticipation != null && goalsParticipation.getChallengeStatus() == ChallengeStatus.PROGRESS) {
-            //챌린지 상태를 실패로 변경
-            goalsParticipation.setChallengeStatus(ChallengeStatus.FAILURE);
+            //챌린지 상태를 포기로 변경
+            goalsParticipation.setChallengeStatus(ChallengeStatus.GIVEUP);
             goalsParticipation.setStatusUpdatedAt(LocalDate.now());
         } else {
             throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
@@ -91,4 +91,11 @@ public class ChallengeGoalsCommandServiceImpl implements ChallengeGoalsCommandSe
 
         return goalsParticipation;
     }
+
+    @Override
+    public void isStatusProgress(User user, ChallengeGoals goals) {
+        if (goalsQueryService.findGoalsParticipation(user, goals).getChallengeStatus() != ChallengeStatus.PROGRESS) {
+            throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
+        }
+    }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
@@ -51,6 +51,7 @@ public class ChallengeGoalsCommandServiceImpl implements ChallengeGoalsCommandSe
 
         goalsParticipationList.forEach(goalsParticipation -> {
             goalsParticipation.setChallengeGoals(newGoals);
+            goalsParticipation.setRoom(newGoals.getRoom());
             goalsParticipationRepository.save(goalsParticipation);
         });
 
@@ -83,6 +84,7 @@ public class ChallengeGoalsCommandServiceImpl implements ChallengeGoalsCommandSe
         if (goalsParticipation != null && goalsParticipation.getChallengeStatus() == ChallengeStatus.PROGRESS) {
             //챌린지 상태를 실패로 변경
             goalsParticipation.setChallengeStatus(ChallengeStatus.FAILURE);
+            goalsParticipation.setStatusUpdatedAt(LocalDate.now());
         } else {
             throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
         }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
@@ -3,8 +3,11 @@ package com.main.writeRoom.service.ChallengeService;
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 
 public interface ChallengeGoalsQueryService {
     public ChallengeGoals findGoals(Long challengeId);
     public Integer findAchieveNote(User user, ChallengeGoals goals);
+
+    public ChallengeGoalsParticipation findGoalsParticipation(User user, ChallengeGoals goals);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
@@ -4,7 +4,9 @@ import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.handler.ChallengeHandler;
+import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
 import com.main.writeRoom.repository.ChallengeGoalsRepository;
 import com.main.writeRoom.repository.NoteRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import java.time.LocalTime;
 public class ChallengeGoalsQueryServiceImpl implements ChallengeGoalsQueryService{
     private final ChallengeGoalsRepository goalsRepository;
     private final NoteRepository noteRepository;
+    private final ChallengeGoalsParticipationRepository goalsParticipationRepository;
 
     @Override
     public ChallengeGoals findGoals(Long challengeId) {
@@ -31,5 +34,10 @@ public class ChallengeGoalsQueryServiceImpl implements ChallengeGoalsQueryServic
             return noteRepository.findAchieveCountNoDate(user, goals.getRoom());
         }
         else return noteRepository.findAchieveCount(goals.getStartDate().atStartOfDay(), goals.getDeadline().atTime(LocalTime.MAX), user,goals.getRoom());
+    }
+
+    @Override
+    public ChallengeGoalsParticipation findGoalsParticipation(User user, ChallengeGoals goals) {
+        return goalsParticipationRepository.findByUserAndChallengeGoals(user, goals);
     }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
@@ -12,5 +12,5 @@ public interface ChallengeRoutineCommandService {
 
     public void deadlineRange(LocalDate startDate, LocalDate deadline);
 
-    public ChallengeRoutineParticipation giveUP(Long userId, Long challengeRoutineId);
+    public ChallengeRoutineParticipation giveUp(Long userId, Long challengeRoutineId);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
@@ -1,6 +1,7 @@
 package com.main.writeRoom.service.ChallengeService;
 
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 
@@ -13,4 +14,5 @@ public interface ChallengeRoutineCommandService {
     public void deadlineRange(LocalDate startDate, LocalDate deadline);
 
     public ChallengeRoutineParticipation giveUp(Long userId, Long challengeRoutineId);
+    public void isStatusProgress(User user, ChallengeRoutine routine);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
@@ -54,6 +54,7 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
 
         challengeRoutineParticipationList.forEach(challengeRoutineParticipation -> {
             challengeRoutineParticipation.setChallengeRoutine(newChallengeRoutine);
+            challengeRoutineParticipation.setRoom(newChallengeRoutine.getRoom());
             //챌린지 참여 테이블에 추가하는 코드
             challengeRoutineParticipationRepository.save(challengeRoutineParticipation);
         } );
@@ -84,6 +85,7 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
         if (routineParticipation != null && routineParticipation.getChallengeStatus() == ChallengeStatus.PROGRESS) {
             //챌린지 상태를 실패로 변경
             routineParticipation.setChallengeStatus(ChallengeStatus.FAILURE);
+            routineParticipation.setStatusUpdatedAt(LocalDate.now());
         } else {
             throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
         }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
@@ -75,7 +75,7 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
 
     @Override
     @Transactional
-    public ChallengeRoutineParticipation giveUP(Long userId, Long routineId) {
+    public ChallengeRoutineParticipation giveUp(Long userId, Long routineId) {
         //회원, 챌린지 조회
         User user = userQueryService.findUser(userId);
         ChallengeRoutine routine = routineQueryService.findRoutine(routineId);

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
@@ -83,8 +83,8 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
         //회원과 챌린지로 챌린지 참여 조회
         ChallengeRoutineParticipation routineParticipation = challengeRoutineParticipationRepository.findByUserAndChallengeRoutine(user, routine);
         if (routineParticipation != null && routineParticipation.getChallengeStatus() == ChallengeStatus.PROGRESS) {
-            //챌린지 상태를 실패로 변경
-            routineParticipation.setChallengeStatus(ChallengeStatus.FAILURE);
+            //챌린지 상태를 포기로 변경
+            routineParticipation.setChallengeStatus(ChallengeStatus.GIVEUP);
             routineParticipation.setStatusUpdatedAt(LocalDate.now());
         } else {
             throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
@@ -93,5 +93,10 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
         return routineParticipation;
     }
 
-
+    @Override
+    public void isStatusProgress(User user, ChallengeRoutine routine) {
+        if (routineQueryService.findRoutineParticipation(user, routine).getChallengeStatus() != ChallengeStatus.PROGRESS) {
+            throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
+        }
+    }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryService.java
@@ -2,6 +2,7 @@ package com.main.writeRoom.service.ChallengeService;
 
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
 
 import java.util.List;
@@ -10,4 +11,5 @@ public interface ChallengeRoutineQueryService {
 
     public ChallengeRoutine findRoutine(Long challengeId);
     public List<ChallengeResponseDTO.NoteDTO> findNoteDate(User user, ChallengeRoutine challengeRoutine);
+    public ChallengeRoutineParticipation findRoutineParticipation(User user, ChallengeRoutine routine);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
@@ -6,9 +6,11 @@ import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.handler.ChallengeHandler;
 import com.main.writeRoom.repository.*;
 import com.main.writeRoom.service.UserService.UserQueryService;
+import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,7 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
     private final ChallengeRoutineRepository routineRepository;
     private final NoteRepository noteRepository;
     private final UserQueryService userQueryService;
+    private final ChallengeRoutineParticipationRepository routineParticipationRepository;
 
     @Override
     public ChallengeRoutine findRoutine(Long challengeId) {
@@ -43,5 +46,8 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
         return noteDTOList;
     }
 
-
+    @Override
+    public ChallengeRoutineParticipation findRoutineParticipation(User user, ChallengeRoutine routine) {
+        return routineParticipationRepository.findByUserAndChallengeRoutine(user, routine);
+    }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandService.java
@@ -1,0 +1,10 @@
+package com.main.writeRoom.service.ChallengeService;
+
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
+
+public interface MyChallengeCommandService {
+    public void inactiveRoutine(ChallengeRoutineParticipation routineParticipation);
+
+    public void inactiveGoals(ChallengeGoalsParticipation goalsParticipation);
+}

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandServiceImpl.java
@@ -1,22 +1,43 @@
 package com.main.writeRoom.service.ChallengeService;
 
+import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.domain.mapping.IsActive;
+import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
+import com.main.writeRoom.repository.ChallengeGoalsRepository;
+import com.main.writeRoom.repository.ChallengeRoutineParticipationRepository;
+import com.main.writeRoom.repository.ChallengeRoutineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MyChallengeCommandServiceImpl implements MyChallengeCommandService{
+    private final ChallengeRoutineRepository routineRepository;
+    private final ChallengeRoutineParticipationRepository routineParticipationRepository;
+    private final ChallengeGoalsRepository goalsRepository;
+    private final ChallengeGoalsParticipationRepository goalsParticipationRepository;
 
-    //나의 챌린지 루틴 내역 삭제
+    //나의 챌린지 루틴 내역 삭제 & 모든 참여자가 내역 삭제 했다면 delete
     @Override
     @Transactional
     public void inactiveRoutine(ChallengeRoutineParticipation routineParticipation) {
         routineParticipation.setIsActive(IsActive.INACTIVE);
+        ChallengeRoutine routine= routineParticipation.getChallengeRoutine();
+        List<ChallengeRoutineParticipation> routineParticipationList = routineParticipationRepository.findByChallengeRoutine(routine);
+        for (ChallengeRoutineParticipation crp :
+                routineParticipationList) {
+            if (crp.getIsActive() == IsActive.ACTIVE)
+                return;
+        }
+        routineParticipationRepository.deleteAll(routineParticipationList);
+        routineRepository.delete(routine);
     }
 
     //나의 챌린지 목표량 내역 삭제
@@ -24,5 +45,14 @@ public class MyChallengeCommandServiceImpl implements MyChallengeCommandService{
     @Transactional
     public void inactiveGoals(ChallengeGoalsParticipation goalsParticipation) {
         goalsParticipation.setIsActive(IsActive.INACTIVE);
+        ChallengeGoals goals= goalsParticipation.getChallengeGoals();
+        List<ChallengeGoalsParticipation> goalsParticipationList = goalsParticipationRepository.findByChallengeGoals(goals);
+        for (ChallengeGoalsParticipation cgp :
+                goalsParticipationList) {
+            if (cgp.getIsActive() == IsActive.ACTIVE)
+                return;
+        }
+        goalsParticipationRepository.deleteAll(goalsParticipationList);
+        goalsRepository.delete(goals);
     }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeCommandServiceImpl.java
@@ -1,0 +1,28 @@
+package com.main.writeRoom.service.ChallengeService;
+
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
+import com.main.writeRoom.domain.mapping.IsActive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MyChallengeCommandServiceImpl implements MyChallengeCommandService{
+
+    //나의 챌린지 루틴 내역 삭제
+    @Override
+    @Transactional
+    public void inactiveRoutine(ChallengeRoutineParticipation routineParticipation) {
+        routineParticipation.setIsActive(IsActive.INACTIVE);
+    }
+
+    //나의 챌린지 목표량 내역 삭제
+    @Override
+    @Transactional
+    public void inactiveGoals(ChallengeGoalsParticipation goalsParticipation) {
+        goalsParticipation.setIsActive(IsActive.INACTIVE);
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryService.java
@@ -2,6 +2,7 @@ package com.main.writeRoom.service.ChallengeService;
 
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
@@ -17,5 +18,6 @@ public interface MyChallengeQueryService {
 
     public List<ChallengeGoalsParticipation> findChallengeGoalsParticipation(Long userId, Long roomId);
 
-    //public List<ChallengeResponseDTO.GetMyChallengeDTO> findTest(Long userId, Long roomId);
+    public ChallengeRoutineParticipation findByUserAndChallengeRoutine(User user, ChallengeRoutine routine);
+    public ChallengeGoalsParticipation findByUserAndChallengeGoals(User user, ChallengeGoals goals);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryService.java
@@ -1,0 +1,21 @@
+package com.main.writeRoom.service.ChallengeService;
+
+import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
+import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
+
+import java.util.List;
+
+public interface MyChallengeQueryService {
+    public List<ChallengeRoutine> findChallengeRoutine(List<ChallengeRoutineParticipation> routineParticipationList);
+
+    public List<ChallengeRoutineParticipation> findChallengeRoutineParticipation(Long userId, Long roomId);
+
+    public List<ChallengeGoals> findChallengeGoals(List<ChallengeGoalsParticipation> goalsParticipationList);
+
+    public List<ChallengeGoalsParticipation> findChallengeGoalsParticipation(Long userId, Long roomId);
+
+    //public List<ChallengeResponseDTO.GetMyChallengeDTO> findTest(Long userId, Long roomId);
+}

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryServiceImpl.java
@@ -1,10 +1,13 @@
 package com.main.writeRoom.service.ChallengeService;
 
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.domain.Challenge.ChallengeGoals;
 import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
+import com.main.writeRoom.handler.ChallengeHandler;
 import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
 import com.main.writeRoom.repository.ChallengeGoalsRepository;
 import com.main.writeRoom.repository.ChallengeRoutineParticipationRepository;
@@ -43,6 +46,7 @@ public class MyChallengeQueryServiceImpl implements MyChallengeQueryService{
         List<ChallengeRoutineParticipation> list = routineParticipationRepository.findByUserAndRoom(userQueryService.findUser(userId), roomQueryService.findRoom(roomId)).stream()
                 .filter(routineParticipation -> routineParticipation.getChallengeStatus() != ChallengeStatus.PROGRESS).collect(Collectors.toList());
 
+        if(list.isEmpty()) throw new ChallengeHandler(ErrorStatus.CHALLENGE_NOTFOUND);
         return list;
     }
 
@@ -58,6 +62,21 @@ public class MyChallengeQueryServiceImpl implements MyChallengeQueryService{
         List<ChallengeGoalsParticipation> list = goalsParticipationRepository.findByUserAndRoom(userQueryService.findUser(userId), roomQueryService.findRoom(roomId)).stream()
                 .filter(goalsParticipation -> goalsParticipation.getChallengeStatus() != ChallengeStatus.PROGRESS).collect(Collectors.toList());
 
+        if(list.isEmpty()) throw new ChallengeHandler(ErrorStatus.CHALLENGE_NOTFOUND);
         return list;
+    }
+
+    @Override
+    public ChallengeRoutineParticipation findByUserAndChallengeRoutine(User user, ChallengeRoutine routine) {
+        ChallengeRoutineParticipation routineParticipation = routineParticipationRepository.findByUserAndChallengeRoutine(user, routine);
+        if (routineParticipation == null) throw new ChallengeHandler(ErrorStatus.NOT_PARTICIPATE);
+        return routineParticipation;
+    }
+
+    @Override
+    public ChallengeGoalsParticipation findByUserAndChallengeGoals(User user, ChallengeGoals goals) {
+        ChallengeGoalsParticipation goalsParticipation = goalsParticipationRepository.findByUserAndChallengeGoals(user, goals);
+        if (goalsParticipation == null) throw new ChallengeHandler(ErrorStatus.NOT_PARTICIPATE);
+        return goalsParticipation;
     }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/MyChallengeQueryServiceImpl.java
@@ -1,0 +1,63 @@
+package com.main.writeRoom.service.ChallengeService;
+
+import com.main.writeRoom.domain.Challenge.ChallengeGoals;
+import com.main.writeRoom.domain.Challenge.ChallengeRoutine;
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
+import com.main.writeRoom.domain.mapping.ChallengeStatus;
+import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
+import com.main.writeRoom.repository.ChallengeGoalsRepository;
+import com.main.writeRoom.repository.ChallengeRoutineParticipationRepository;
+import com.main.writeRoom.repository.ChallengeRoutineRepository;
+import com.main.writeRoom.service.RoomService.RoomQueryService;
+import com.main.writeRoom.service.UserService.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MyChallengeQueryServiceImpl implements MyChallengeQueryService{
+    private final ChallengeRoutineRepository routineRepository;
+    private final ChallengeGoalsRepository goalsRepository;
+    private final ChallengeRoutineParticipationRepository routineParticipationRepository;
+    private final ChallengeGoalsParticipationRepository goalsParticipationRepository;
+    private final UserQueryService userQueryService;
+    private final RoomQueryService roomQueryService;
+
+    @Override
+    public List<ChallengeRoutine> findChallengeRoutine(List<ChallengeRoutineParticipation> routineParticipationList) {
+
+        return routineParticipationList.stream()
+                .map(routineParticipation ->
+                        routineParticipation.getChallengeRoutine()).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ChallengeRoutineParticipation> findChallengeRoutineParticipation(Long userId, Long roomId) {
+
+        List<ChallengeRoutineParticipation> list = routineParticipationRepository.findByUserAndRoom(userQueryService.findUser(userId), roomQueryService.findRoom(roomId)).stream()
+                .filter(routineParticipation -> routineParticipation.getChallengeStatus() != ChallengeStatus.PROGRESS).collect(Collectors.toList());
+
+        return list;
+    }
+
+    @Override
+    public List<ChallengeGoals> findChallengeGoals(List<ChallengeGoalsParticipation> goalsParticipationList) {
+        return goalsParticipationList.stream()
+                .map(goalsParticipation ->
+                        goalsParticipation.getChallengeGoals()).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ChallengeGoalsParticipation> findChallengeGoalsParticipation(Long userId, Long roomId) {
+        List<ChallengeGoalsParticipation> list = goalsParticipationRepository.findByUserAndRoom(userQueryService.findUser(userId), roomQueryService.findRoom(roomId)).stream()
+                .filter(goalsParticipation -> goalsParticipation.getChallengeStatus() != ChallengeStatus.PROGRESS).collect(Collectors.toList());
+
+        return list;
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
@@ -4,6 +4,8 @@ import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
 import java.util.List;
+
+import com.main.writeRoom.domain.User.User;
 import org.springframework.data.domain.Page;
 
 public interface NoteQueryService {
@@ -11,4 +13,5 @@ public interface NoteQueryService {
     List<Note> findNoteForCategoryAndRoom(Category category, Room room);
     Page<Note> getNoteListForRoom(Room room, Integer page);
     Note findNote(Long noteId);
+    public Page<Note> findNoteListForRoomAndUser(Room room, User user, Integer page);
 }

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.handler.NoteHandler;
 import com.main.writeRoom.repository.NoteRepository;
 import java.util.List;
@@ -35,5 +36,10 @@ public class NoteQueryServiceImpl implements NoteQueryService{
     public Page<Note> findNoteForRoomAndCategory(Category category, Room room, Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10);
         return noteRepository.findAllByRoomAndCategory(room, category, pageRequest);
+    }
+
+    public Page<Note> findNoteListForRoomAndUser(Room room, User user, Integer page) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        return noteRepository.findAllByRoomAndUser(room, user, pageRequest);
     }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -118,14 +118,33 @@ public class ChallengeResponseDTO {
         ChallengeStatus status; //챌린지 상태(성공 or 실패) - ChallengeRoutineParticipation, ChallengeGoalsParticipation
     }
 
+    //나의 챌린지 상세 조회
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class GetMyChallengeDTO { //db의 조회결과를 담는 dto
-        Long challengeId;
-        List<ChallengeGoalsParticipation> participantList;
-        LocalDate endDate;
-        ChallengeStatus status;
+    public static class MyChallengeRoutineDTO {
+        String userName;     //회원명
+        List<UserDTO> userList; //챌린지 참여자 목록
+        LocalDate startDate; //시작 날짜
+        LocalDate deadline;  //마감 날짜
+        Integer targetCount; //목표 일수
+        List<NoteDTO> noteList; //챌린지 기간동안 작성한 노트들의 인덱스와 날짜 목록
+        ChallengeStatus challengeStatus; //챌린지 성공여부
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyChallengeGoalsDTO {
+        String userName;     //회원명
+        Integer achieveCount; //기간 동안의 200자 이상인 노트의 수
+        List<UserDTO> userList; //챌린지 참여자 목록
+        LocalDate startDate; //시작 날짜
+        LocalDate deadline;  //마감 날짜
+        Integer targetCount; //목표 일수
+        ChallengeStatus challengeStatus; //챌린지 성공 여부
+    }
+
 }

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -146,5 +146,4 @@ public class ChallengeResponseDTO {
         Integer targetCount; //목표 일수
         ChallengeStatus challengeStatus; //챌린지 성공 여부
     }
-
 }

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -5,6 +5,7 @@ import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
+import com.main.writeRoom.web.dto.note.NoteResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,8 +66,11 @@ public class ChallengeResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class NoteListByDateDTO{
-        Room room;  //룸의 노트 중 200자 이상인 노트를 조회
+    public static class RoomResultByDate{ //룸의 노트 중 해당 날짜의 200자 이상인 노트를 조회
+        Long roomId;
+        String roomTitle;
+        String roomIntroduction;
+        List<NoteResponseDTO.NoteList> noteList;
     }
 
     //5. 챌린지 루틴, 목표량 포기 결과 dto

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -3,6 +3,7 @@ package com.main.writeRoom.web.dto.challenge;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.ChallengeGoalsParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -93,5 +94,38 @@ public class ChallengeResponseDTO {
         LocalDate startDate; //시작 날짜
         LocalDate deadline;  //마감 날짜
         Integer targetCount; //목표 일수
+    }
+
+    //나의 챌린지
+    //나의 챌린지 이력 조회
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyChallengeListDTO {
+        List<MyChallengeDTO> myChallengeRoutineDTOList; //챌린지 루틴 이력
+        List<MyChallengeDTO> myChallengeGoalsDTOList;   //챌린지 목표량 이력
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyChallengeDTO { //응답 결과의 일부
+        String challengeName;
+        List<UserDTO> participantList; //참여자 목록 - ChallengeRoutine, ChallengeGoals
+        LocalDate endDate; //챌린지 종료일자 - ChallengeRoutineParticipation, ChallengeGoalsParticipation
+        ChallengeStatus status; //챌린지 상태(성공 or 실패) - ChallengeRoutineParticipation, ChallengeGoalsParticipation
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMyChallengeDTO { //db의 조회결과를 담는 dto
+        Long challengeId;
+        List<ChallengeGoalsParticipation> participantList;
+        LocalDate endDate;
+        ChallengeStatus status;
     }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -24,7 +24,6 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class CreateChallengeResultDTO {
         Long challengeId;
-        LocalDateTime createdAt;
     }
 
     //2. 챌린지 루틴 조회
@@ -34,6 +33,7 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class ChallengeRoutineDTO {
 
+        Long challengeId;    //챌린지 루틴 식별자
         String userName;     //회원명
         List<UserDTO> userList; //챌린지 참여자 목록
         LocalDate startDate; //시작 날짜
@@ -92,6 +92,7 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class ChallengeGoalsDTO {
 
+        Long challengeId;    //챌린지 목표량 식별자
         String userName;     //회원명
         Integer achieveCount; //기간 동안의 200자 이상인 노트의 수
         List<UserDTO> userList; //챌린지 참여자 목록
@@ -116,7 +117,9 @@ public class ChallengeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MyChallengeDTO { //응답 결과의 일부
-        String challengeName;
+
+        Long challengeId; //챌린지 식별자
+        String challengeName; //챌린지명
         List<UserDTO> participantList; //참여자 목록 - ChallengeRoutine, ChallengeGoals
         LocalDate endDate; //챌린지 종료일자 - ChallengeRoutineParticipation, ChallengeGoalsParticipation
         ChallengeStatus status; //챌린지 상태(성공 or 실패) - ChallengeRoutineParticipation, ChallengeGoalsParticipation
@@ -128,6 +131,8 @@ public class ChallengeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MyChallengeRoutineDTO {
+
+        Long challengeId;    //챌린지 루틴 식별자
         String userName;     //회원명
         List<UserDTO> userList; //챌린지 참여자 목록
         LocalDate startDate; //시작 날짜
@@ -142,6 +147,8 @@ public class ChallengeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MyChallengeGoalsDTO {
+
+        Long challengeId;    //챌린지 목표량 식별자
         String userName;     //회원명
         Integer achieveCount; //기간 동안의 200자 이상인 노트의 수
         List<UserDTO> userList; //챌린지 참여자 목록


### PR DESCRIPTION
### 이슈

- #30 

### 작업 내용

- 나의 챌린지 목록 조회 API
- 나의 챌린지 상세 조회 API - 루틴
- 나의 챌린지 상세 조회 API - 목표량
- 나의 챌린지 내역 삭제 API - 루틴
- 나의 챌린지 내역 삭제 API - 목표량
- 스탬프 클릭 시, 날짜에 해당하는 조건 달성 노트 조회 API
- 챌린지 참여에 상태변경시간, 룸 fk 칼럼추가
- delete 기능 추가
- get 응답에 id도 응답하도록 추가
- 에러 추가