### PR TITLE
[FEAT] 이메일 로그인, 회원가입 구현 #46

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
 	// aws cloud
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -19,6 +19,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4002", "이메일이 존재하지 않습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4003", "비밀번호가 일치하지 않습니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "USER4004", "이미 존재하는 이메일입니다."),
+
 
     PAGE_LESS_NULL(HttpStatus.BAD_REQUEST, "PAGE4001", "Page는 0부터 입니다."),
     ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROOM4001", "룸이 없습니다."),

--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -15,7 +15,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
+    // 유저 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4002", "이메일이 존재하지 않습니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4003", "비밀번호가 일치하지 않습니다."),
+
     PAGE_LESS_NULL(HttpStatus.BAD_REQUEST, "PAGE4001", "Page는 0부터 입니다."),
     ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROOM4001", "룸이 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "카테고리가 없습니다."),

--- a/src/main/java/com/main/writeRoom/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/main/writeRoom/config/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package com.main.writeRoom.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/SecurityConfig.java
+++ b/src/main/java/com/main/writeRoom/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.main.writeRoom.config;
+
+import com.main.writeRoom.config.filter.JwtAuthFilter;
+import com.main.writeRoom.config.utils.JwtUtil;
+import com.main.writeRoom.handler.CustomAccessDeniedHandler;
+import com.main.writeRoom.handler.CustomAuthenticationEntryPoint;
+import com.main.writeRoom.service.UserService.CustomUserDetailsService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@AllArgsConstructor
+public class SecurityConfig {
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/api/vi/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/vi/auth/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // CSRF, CORS
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.cors(Customizer.withDefaults());
+
+        // 세션 관리 상태 없음으로 구성, Spring Security 가 세션 생성 or 사용 X
+        http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS));
+
+        // FormLogin, BasicHttp 비활성화
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        //JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+        http.addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling((exceptionHandling) -> exceptionHandling
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler)
+        );
+
+        // 권한 규칙 작성
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(AUTH_WHITELIST).permitAll()
+                //@PreAuthorization을 사용할 것이기 때문에 모든 경로에 대한 인증 처리는 Pass
+                .anyRequest().permitAll()
+        );
+        return http.build();
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/SecurityConfig.java
+++ b/src/main/java/com/main/writeRoom/config/SecurityConfig.java
@@ -51,14 +51,14 @@ public class SecurityConfig {
 
         http.exceptionHandling((exceptionHandling) -> exceptionHandling
                 .authenticationEntryPoint(authenticationEntryPoint)
-                .accessDeniedHandler(accessDeniedHandler)
+                    .accessDeniedHandler(accessDeniedHandler)
         );
 
         // 권한 규칙 작성
         http.authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(AUTH_WHITELIST).permitAll()
                 //@PreAuthorization을 사용할 것이기 때문에 모든 경로에 대한 인증 처리는 Pass
-                .anyRequest().permitAll()
+                .anyRequest().authenticated()
         );
         return http.build();
     }

--- a/src/main/java/com/main/writeRoom/config/SecurityConfig.java
+++ b/src/main/java/com/main/writeRoom/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/vi/member/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/vi/auth/**"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/vi/auth/**", "/auth/**"
     };
 
     @Bean

--- a/src/main/java/com/main/writeRoom/config/WebConfig.java
+++ b/src/main/java/com/main/writeRoom/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.main.writeRoom.config;
+
+import com.main.writeRoom.config.auth.AuthenticationArgumentResolver;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authenticationArgumentResolver);
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/auth/AuthUser.java
+++ b/src/main/java/com/main/writeRoom/config/auth/AuthUser.java
@@ -1,5 +1,6 @@
 package com.main.writeRoom.config.auth;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +8,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(name = "user", description = "user", hidden = true)
 public @interface AuthUser {
 }

--- a/src/main/java/com/main/writeRoom/config/auth/AuthUser.java
+++ b/src/main/java/com/main/writeRoom/config/auth/AuthUser.java
@@ -1,0 +1,11 @@
+package com.main.writeRoom.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}

--- a/src/main/java/com/main/writeRoom/config/auth/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/main/writeRoom/config/auth/AuthenticationArgumentResolver.java
@@ -4,6 +4,7 @@ import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.config.utils.JwtUtil;
 import com.main.writeRoom.handler.UserHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -25,7 +26,7 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer mavContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
 
         String authorizationHeader = httpServletRequest.getHeader("Authorization");

--- a/src/main/java/com/main/writeRoom/config/auth/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/main/writeRoom/config/auth/AuthenticationArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.main.writeRoom.config.auth;
+
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.config.utils.JwtUtil;
+import com.main.writeRoom.handler.UserHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtUtil jwtUtil;
+
+    public AuthenticationArgumentResolver(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(AuthUser.class) != null && parameter.getParameterType().equals(long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String authorizationHeader = httpServletRequest.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            return jwtUtil.getUserId(token);
+        } else {
+            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/filter/JwtAuthFilter.java
+++ b/src/main/java/com/main/writeRoom/config/filter/JwtAuthFilter.java
@@ -1,0 +1,50 @@
+package com.main.writeRoom.config.filter;
+
+import com.main.writeRoom.config.utils.JwtUtil;
+import com.main.writeRoom.service.UserService.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    /**
+     * JWT 토큰 검증 필터 수행
+     */
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        // JWT가 헤더에 있는 경우
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            // JWT 유효성 검증
+            if (jwtUtil.validateToken(token)) {
+                Long userId = jwtUtil.getUserId(token);
+
+                // 유저와 토큰 일치 시 userDetails 생성
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+
+                if (userDetails != null) {
+                    // UserDetails, Password, Role -> 접근 권한 인증 Token 생성
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                    // 현재의 Request의 Security Context에 접근권한 설정
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/utils/JwtUtil.java
+++ b/src/main/java/com/main/writeRoom/config/utils/JwtUtil.java
@@ -1,0 +1,96 @@
+package com.main.writeRoom.config.utils;
+
+import com.main.writeRoom.web.dto.user.UserResponseDTO.CustomUserInfo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * [JWT 관련 메서드를 제공하는 클래스]
+ */
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final long accessTokenExpTime;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.expiration_time") long accessTokenExpTime
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
+    }
+
+    /**
+     * Access Token 생성
+     * @param user
+     * @param expireTime
+     */
+    private String createToken(CustomUserInfo user, long expireTime) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", user.getUserId());
+        claims.put("email", user.getEmail());
+        claims.put("role", user.getRole());
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(expireTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Token 에서 User ID 추출
+     */
+    public Long getUserId(String token) {
+        return parseClaims(token).get("userId", Long.class);
+    }
+
+    /**
+     * JWT 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token", e);
+        } catch (IllegalArgumentException e) {
+                log.info("JWT claims string is empty", e);
+            }
+            return false;
+    }
+
+    /**
+     * JWT Claims 추출
+     */
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/main/writeRoom/config/utils/JwtUtil.java
+++ b/src/main/java/com/main/writeRoom/config/utils/JwtUtil.java
@@ -28,7 +28,7 @@ public class JwtUtil {
 
     public JwtUtil(
             @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.expiration_time") long accessTokenExpTime
+            @Value("${jwt.expiration_time}") long accessTokenExpTime
     ) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
@@ -36,7 +36,14 @@ public class JwtUtil {
     }
 
     /**
-     * Access Token 생성
+     * AccessToken 생성
+     */
+    public String createAccessToken(CustomUserInfo user) {
+        return createToken(user, accessTokenExpTime);
+    }
+
+    /**
+     * JWT 생성
      * @param user
      * @param expireTime
      */

--- a/src/main/java/com/main/writeRoom/controller/AuthController.java
+++ b/src/main/java/com/main/writeRoom/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.main.writeRoom.controller;
 
 import com.main.writeRoom.apiPayload.ApiResponse;
 import com.main.writeRoom.apiPayload.status.SuccessStatus;
+import com.main.writeRoom.converter.UserConverter;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.service.AuthService.AuthService;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
 import com.main.writeRoom.web.dto.user.UserResponseDTO;
@@ -22,5 +24,11 @@ public class AuthController {
     public ApiResponse<UserResponseDTO.UserSignInResult> signIn(@RequestBody UserRequestDTO.UserSignIn request) {
         UserSignInResult response = authService.login(request);
         return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    @PostMapping("/signUp")
+    public ApiResponse<UserResponseDTO.CustomUserInfo> addUser(@RequestBody UserRequestDTO.UserSignUp request) {
+        User user = authService.join(request);
+        return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
     }
 }

--- a/src/main/java/com/main/writeRoom/controller/AuthController.java
+++ b/src/main/java/com/main/writeRoom/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.main.writeRoom.controller;
+
+import com.main.writeRoom.apiPayload.ApiResponse;
+import com.main.writeRoom.apiPayload.status.SuccessStatus;
+import com.main.writeRoom.service.AuthService.AuthService;
+import com.main.writeRoom.web.dto.user.UserRequestDTO;
+import com.main.writeRoom.web.dto.user.UserResponseDTO;
+import com.main.writeRoom.web.dto.user.UserResponseDTO.UserSignInResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signIn")
+    public ApiResponse<UserResponseDTO.UserSignInResult> signIn(@RequestBody UserRequestDTO.UserSignIn request) {
+        UserSignInResult response = authService.login(request);
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/main/writeRoom/controller/RoomController.java
+++ b/src/main/java/com/main/writeRoom/controller/RoomController.java
@@ -56,7 +56,7 @@ public class RoomController {
     private final CategoryQueryService categoryQueryService;
     private final RoomParticipationService roomParticipationService;
 
-    @GetMapping("/")
+    @GetMapping("/myRoomList")
     @Operation(summary = "나의 룸 목록 조회 API", description = "해당 유저가 참여중인 룸의 목록들을 조회하는 API이며, 페이징을 포함합니다. query String으로 page 번호를 주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
@@ -64,9 +64,12 @@ public class RoomController {
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "Page는 0부터 입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON401", description = "인증이 필요합니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
     })
     @Parameters({
-            @Parameter(name = "page", description = "페이지 번호, 0번이 1번 페이지 입니다."),
+            @Parameter(name = "user", description = "user", hidden = true),
+            @Parameter(name = "page", description = "페이지 번호, 0번이 1번 페이지 입니다.")
     })
     public ApiResponse<List<MyRoomResultDto>> myRoomList(@AuthUser long user, @PageLessNull @RequestParam(name = "page") Integer page) {
         Page<RoomParticipation> room = roomCommandService.getMyRoomResultList(user, page);

--- a/src/main/java/com/main/writeRoom/controller/RoomController.java
+++ b/src/main/java/com/main/writeRoom/controller/RoomController.java
@@ -3,6 +3,7 @@ package com.main.writeRoom.controller;
 import com.main.writeRoom.apiPayload.ApiResponse;
 import com.main.writeRoom.apiPayload.code.ErrorReasonDTO;
 import com.main.writeRoom.apiPayload.status.SuccessStatus;
+import com.main.writeRoom.config.auth.AuthUser;
 import com.main.writeRoom.converter.NoteConverter;
 import com.main.writeRoom.converter.RoomConverter;
 import com.main.writeRoom.domain.Category;
@@ -55,7 +56,7 @@ public class RoomController {
     private final CategoryQueryService categoryQueryService;
     private final RoomParticipationService roomParticipationService;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/")
     @Operation(summary = "나의 룸 목록 조회 API", description = "해당 유저가 참여중인 룸의 목록들을 조회하는 API이며, 페이징을 포함합니다. query String으로 page 번호를 주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
@@ -67,8 +68,8 @@ public class RoomController {
     @Parameters({
             @Parameter(name = "page", description = "페이지 번호, 0번이 1번 페이지 입니다."),
     })
-    public ApiResponse<List<MyRoomResultDto>> myRoomList(@PathVariable(name = "userId") Long userId, @PageLessNull @RequestParam(name = "page") Integer page) {
-        Page<RoomParticipation> room = roomCommandService.getMyRoomResultList(userId, page);
+    public ApiResponse<List<MyRoomResultDto>> myRoomList(@AuthUser long user, @PageLessNull @RequestParam(name = "page") Integer page) {
+        Page<RoomParticipation> room = roomCommandService.getMyRoomResultList(user, page);
         return ApiResponse.of(SuccessStatus._OK, RoomConverter.myRoomListInfoDTO(room));
     }
 

--- a/src/main/java/com/main/writeRoom/converter/UserConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/UserConverter.java
@@ -1,6 +1,8 @@
 package com.main.writeRoom.converter;
 
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.enums.Role;
+import com.main.writeRoom.web.dto.user.UserRequestDTO;
 import com.main.writeRoom.web.dto.user.UserResponseDTO;
 
 public class UserConverter {
@@ -26,6 +28,15 @@ public class UserConverter {
                 .userId(user.getId())
                 .email(user.getEmail())
                 .role(user.getRole())
+                .build();
+    }
+
+    public static User UserSignUpDTO(UserRequestDTO.UserSignUp request, String password) {
+        return User.builder()
+                .email(request.getEmail())
+                .name(request.getNickName())
+                .password(password)
+                .role(Role.USER)
                 .build();
     }
 }

--- a/src/main/java/com/main/writeRoom/converter/UserConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/UserConverter.java
@@ -1,0 +1,31 @@
+package com.main.writeRoom.converter;
+
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.web.dto.user.UserResponseDTO;
+
+public class UserConverter {
+
+    public static UserResponseDTO.UserSignInResult UserSignInResultDTO(User user, String accessToken) {
+        return UserResponseDTO.UserSignInResult.builder()
+                .userId(user.getId())
+                .accessToken(accessToken)
+                .build();
+    }
+
+    public static UserResponseDTO.CustomUserInfoDTO CustomUserResultDTO(User user) {
+        return UserResponseDTO.CustomUserInfoDTO.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .role(user.getRole())
+                .build();
+    }
+
+    public static UserResponseDTO.CustomUserInfo CustomUserInfoResultDTO(User user) {
+        return UserResponseDTO.CustomUserInfo.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/main/writeRoom/domain/User/User.java
+++ b/src/main/java/com/main/writeRoom/domain/User/User.java
@@ -1,6 +1,7 @@
 package com.main.writeRoom.domain.User;
 
 import com.main.writeRoom.common.BaseEntity;
+import com.main.writeRoom.domain.enums.Role;
 import com.main.writeRoom.domain.mapping.RoomParticipation;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -32,6 +33,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private JoinType joinType;
     private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @OneToMany(mappedBy = "user")
     private List<RoomParticipation> roomParticipationList = new ArrayList<>();

--- a/src/main/java/com/main/writeRoom/domain/enums/Role.java
+++ b/src/main/java/com/main/writeRoom/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.main.writeRoom.domain.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/main/writeRoom/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/main/writeRoom/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.main.writeRoom.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.main.writeRoom.web.dto.user.UserResponseDTO.ErrorResponseDTO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "FORBIDDEN_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("No Authorities", accessDeniedException);
+
+        ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO(HttpStatus.FORBIDDEN.value(), accessDeniedException.getMessage(),
+                LocalDateTime.now());
+
+        String responseBody = objectMapper.writeValueAsString(errorResponseDTO);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/main/writeRoom/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/main/writeRoom/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.main.writeRoom.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.main.writeRoom.web.dto.user.UserResponseDTO.ErrorResponseDTO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authenticationException) throws IOException, ServletException {
+        log.error("No Authenticated Request", authenticationException);
+
+        ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO(HttpStatus.FORBIDDEN.value(),
+                authenticationException.getMessage(), LocalDateTime.now());
+
+        String responseBody = objectMapper.writeValueAsString(errorResponseDTO);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/main/writeRoom/repository/UserRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByEmail(String email);
 }

--- a/src/main/java/com/main/writeRoom/repository/UserRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
@@ -1,8 +1,10 @@
 package com.main.writeRoom.service.AuthService;
 
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
 import com.main.writeRoom.web.dto.user.UserResponseDTO;
 
 public interface AuthService {
     UserResponseDTO.UserSignInResult login(UserRequestDTO.UserSignIn request);
+    User join(UserRequestDTO.UserSignUp request);
 }

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
@@ -1,0 +1,8 @@
+package com.main.writeRoom.service.AuthService;
+
+import com.main.writeRoom.web.dto.user.UserRequestDTO;
+import com.main.writeRoom.web.dto.user.UserResponseDTO;
+
+public interface AuthService {
+    UserResponseDTO.UserSignInResult login(UserRequestDTO.UserSignIn request);
+}

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
@@ -40,4 +40,16 @@ public class AuthServiceImpl implements AuthService{
 
         return UserConverter.UserSignInResultDTO(user, accessToken);
     }
+
+    @Transactional
+    public User join(UserRequestDTO.UserSignUp request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new UserHandler(ErrorStatus.EXIST_EMAIL);
+        }
+        // 비밀번호 해시 처리
+        String password = encoder.encode(request.getPassword());
+
+        User user = UserConverter.UserSignUpDTO(request, password);
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
@@ -1,0 +1,43 @@
+package com.main.writeRoom.service.AuthService;
+
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.config.utils.JwtUtil;
+import com.main.writeRoom.converter.UserConverter;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.handler.UserHandler;
+import com.main.writeRoom.repository.UserRepository;
+import com.main.writeRoom.web.dto.user.UserRequestDTO;
+import com.main.writeRoom.web.dto.user.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthServiceImpl implements AuthService{
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder encoder;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserResponseDTO.UserSignInResult login(UserRequestDTO.UserSignIn request) {
+
+        User user = userRepository.findByEmail(request.getEmail());
+        if (user == null) {
+            throw new UserHandler(ErrorStatus.EMAIL_NOT_FOUND);
+        }
+
+        // 암호화된 password를 디코딩한 값과 입력한 패스워드 값이 다르면 null 반환
+        if (!encoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UserHandler(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
+
+        UserResponseDTO.CustomUserInfo info = UserConverter.CustomUserInfoResultDTO(user);
+
+        String accessToken = jwtUtil.createAccessToken(info);
+
+        return UserConverter.UserSignInResultDTO(user, accessToken);
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/UserService/CustomUserDetails.java
+++ b/src/main/java/com/main/writeRoom/service/UserService/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package com.main.writeRoom.service.UserService;
+
+import com.main.writeRoom.web.dto.user.UserResponseDTO.CustomUserInfoDTO;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final CustomUserInfoDTO user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_" + user.getUserId().toString());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/UserService/CustomUserDetailsService.java
+++ b/src/main/java/com/main/writeRoom/service/UserService/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.main.writeRoom.service.UserService;
+
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.converter.UserConverter;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.handler.UserHandler;
+import com.main.writeRoom.repository.UserRepository;
+import com.main.writeRoom.web.dto.user.UserResponseDTO.CustomUserInfoDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(id))
+                .orElseThrow(() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        CustomUserInfoDTO dto = UserConverter.CustomUserResultDTO(user);
+
+        return new CustomUserDetails(dto);
+    }
+}

--- a/src/main/java/com/main/writeRoom/web/dto/user/UserRequestDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/user/UserRequestDTO.java
@@ -13,4 +13,17 @@ public class UserRequestDTO {
         @NotNull(message = "비밀번호 입력은 필수입니다.")
         String password;
     }
+
+    @Getter
+    public static class UserSignUp{
+        @Email
+        @NotNull(message = "이메일 입력은 필수입니다.")
+        String email;
+
+        @NotNull(message = "비밀번호 입력은 필수입니다.")
+        String password;
+
+        @NotNull(message = "닉네임 입력은 필수입니다.")
+        String nickName;
+    }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/user/UserRequestDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/user/UserRequestDTO.java
@@ -1,0 +1,16 @@
+package com.main.writeRoom.web.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class UserRequestDTO {
+    @Getter
+    public static class UserSignIn {
+        @NotNull(message = "이메일 입력은 필수입니다.")
+        @Email
+        String email;
+        @NotNull(message = "비밀번호 입력은 필수입니다.")
+        String password;
+    }
+}

--- a/src/main/java/com/main/writeRoom/web/dto/user/UserResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/user/UserResponseDTO.java
@@ -1,5 +1,7 @@
 package com.main.writeRoom.web.dto.user;
 
+import com.main.writeRoom.domain.enums.Role;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +16,38 @@ public class UserResponseDTO {
     public static class CustomUserInfo {
         Long userId;
         String email;
-        String role;
+        Role role;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CustomUserInfoDTO {
+        Long userId;
+        String email;
+        String name;
+        String password;
+        Role role;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserSignInResult {
+        Long userId;
+        String accessToken;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ErrorResponseDTO {
+
+        private int statusCode;
+        private String message;
+        private LocalDateTime timestamp;
     }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/user/UserResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/user/UserResponseDTO.java
@@ -1,0 +1,19 @@
+package com.main.writeRoom.web.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CustomUserInfo {
+        Long userId;
+        String email;
+        String role;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,7 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY_ID}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
+
+jwt:
+  expiration_time: 86400000
+  secret: ${jwt_secret}


### PR DESCRIPTION
## 이슈 
- https://github.com/WRITE-ROOM/SERVER/issues/46

 <br>

## 작업 내용
- 스프링 시큐리티 이용한 유저 관리 
- 이메일 회원가입
- 이메일 로그인
- 중복 이메일 체크
- 비밀번호 불일치 체크
- HandlerMethodArgumentResolver 추가

<br>

## 참고사항
- https://sjh9708.tistory.com/170 -> 제가 참고한 스프링 시큐리티 관련 블로그입니다. 

- HandlerMethodArgumentResolver 관련해서 [노션](https://profuse-mammal-47c.notion.site/9c115687d5f645c4bf395182f7c1539c?pvs=4)에 정리해두겠습니다. 참고하면서 구현해주세요!
- 밑에는 컨트롤러에서 resolver 사용한 코드입니다. @/AuthUser

`public ApiResponse<List<MyRoomResultDto>> myRoomList(@AuthUser long user, @PageLessNull @RequestParam(name = "page") Integer page) {
        Page<RoomParticipation> room = roomCommandService.getMyRoomResultList(user, page);
        return ApiResponse.of(SuccessStatus._OK, RoomConverter.myRoomListInfoDTO(room));
    }`
