### PR TITLE
[REFACTOR] 카테고리 목록 조회 API 수정 [FIX] 룸 삭제 시 노트 태그 리스트도 삭제 #53

### DIFF
--- a/src/main/java/com/main/writeRoom/converter/CategoryConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/CategoryConverter.java
@@ -37,6 +37,7 @@ public class CategoryConverter {
         return CategoryResponseDTO.CategoryList.builder()
                 .categoryId(category.getId())
                 .countNote(countNote)
+                .categoryName(category.getName())
                 .build();
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/Note.java
+++ b/src/main/java/com/main/writeRoom/domain/Note.java
@@ -1,5 +1,6 @@
 package com.main.writeRoom.domain;
 
+import com.main.writeRoom.domain.Bookmark.BookmarkNote;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.common.BaseEntity;
 import com.main.writeRoom.domain.mapping.NoteTag;
@@ -42,8 +43,11 @@ public class Note extends BaseEntity {
     @JoinColumn(name = "category")
     private Category category;
 
-    @OneToMany(mappedBy = "note")
+    @OneToMany(mappedBy = "note",cascade = CascadeType.ALL)
     private List<NoteTag> noteTagList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL)
+    private List<BookmarkNote> bookmarkNoteList = new ArrayList<>();
 
     public String daysSinceLastUpdate() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/main/writeRoom/domain/Room.java
+++ b/src/main/java/com/main/writeRoom/domain/Room.java
@@ -41,6 +41,8 @@ public class Room extends BaseEntity {
     private List<RoomParticipation> roomParticipationList = new ArrayList<>();
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
     private List<Note> noteList = new ArrayList<>();
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
+    private List<Category> categoryList = new ArrayList<>();
 
     public String daysSinceLastUpdate() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/main/writeRoom/domain/Tag.java
+++ b/src/main/java/com/main/writeRoom/domain/Tag.java
@@ -24,10 +24,6 @@ public class Tag extends BaseEntity {
 
     private String content;
 
-    @ManyToOne
-    @JoinColumn(name = "category")
-    private Category category;
-
     @OneToMany(mappedBy = "tag")
     private List<NoteTag> noteTagList = new ArrayList<>();
 }

--- a/src/main/java/com/main/writeRoom/web/dto/category/CategoryResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/category/CategoryResponseDTO.java
@@ -25,5 +25,6 @@ public class CategoryResponseDTO {
     public static class CategoryList {
         Long categoryId;
         Long countNote;
+        String categoryName;
     }
 }


### PR DESCRIPTION
## 이슈
- https://github.com/WRITE-ROOM/SERVER/issues/53

<br>

## 작업 내용
- 전체 노트 카운트, 카테고리에 속해있는 노트 카운트 조회 api의 response에 카테고리 이름 추가
- 룸 삭제 시 노트에 할당되어 있는 노트 태그도 같이 삭제되게끔 기능 수정