### PR TITLE
[FIX] 룸 도메인 기능 수정 #60

### DIFF
--- a/src/main/java/com/main/writeRoom/converter/NoteConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/NoteConverter.java
@@ -19,6 +19,8 @@ public static NoteResponseDTO.RoomResult toRoomResultDTO(Room room, Page<Note> n
 
     return NoteResponseDTO.RoomResult.builder()
             .roomId(room.getId())
+            .roomTitle(room.getTitle())
+            .roomIntroduction(room.getIntroduction())
             .noteList(toRoomResultNoteDTOList)
             .build();
 }

--- a/src/main/java/com/main/writeRoom/converter/RoomConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/RoomConverter.java
@@ -70,7 +70,6 @@ public class RoomConverter {
     public static Room toRoom(RoomRequestDTO.CreateRoomDTO request, String imgUrl) {
         return Room.builder()
                 .title(request.getRoomTitle())
-                .introduction(request.getRoomContent())
                 .coverImg(imgUrl)
                 .build();
     }

--- a/src/main/java/com/main/writeRoom/web/dto/room/RoomRequestDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/room/RoomRequestDTO.java
@@ -2,7 +2,6 @@ package com.main.writeRoom.web.dto.room;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 public class RoomRequestDTO {
 
@@ -10,7 +9,5 @@ public class RoomRequestDTO {
     public static class CreateRoomDTO {
         @NotBlank
         String roomTitle;
-        @NotBlank
-        String roomContent;
     }
 }


### PR DESCRIPTION
## 이슈 
- https://github.com/WRITE-ROOM/SERVER/issues/60

<br>

## 작업 내용
- 룸에 해당하는 노트 목록 조회 응답 데이터에서 룸 제목, 룸 소개 추가
- 룸 생성시 요청 값에 룸 소개 삭제