### PR TITLE
[FEAT] 노트 조회 API 구현 + 이모지 CUD API 구현

### DIFF
--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTHORITY_TYPE_ERROR(HttpStatus.BAD_REQUEST, "AUTHORITY4002", "올바른 권한 형식을 입력하세요."),
     BOOKMARK_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOKMARK4001", "해당하는 Id의 북마크가 없습니다."),
     EMOJI_NOT_FOUNT(HttpStatus.BAD_REQUEST, "EMOJI4001", "사용자가 남긴 이모지가 없습니다."),
+    EMOJI_REPOST(HttpStatus.BAD_REQUEST, "EMOJI4002", "이미 해당 노트에 이모지를 등록 했습니다."),
 
     //챌린지 에러
     ROUTINE_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4001", "챌린지 루틴이 없습니다."),

--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTHORITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTHORITY4001", "권한이 없습니다."),
     AUTHORITY_TYPE_ERROR(HttpStatus.BAD_REQUEST, "AUTHORITY4002", "올바른 권한 형식을 입력하세요."),
     BOOKMARK_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOKMARK4001", "해당하는 Id의 북마크가 없습니다."),
+    EMOJI_NOT_FOUNT(HttpStatus.BAD_REQUEST, "EMOJI4001", "사용자가 남긴 이모지가 없습니다."),
 
     //챌린지 에러
     ROUTINE_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4001", "챌린지 루틴이 없습니다."),

--- a/src/main/java/com/main/writeRoom/controller/EmojiController.java
+++ b/src/main/java/com/main/writeRoom/controller/EmojiController.java
@@ -41,12 +41,12 @@ public class EmojiController {
     private final EmojiCommandService emojiCommandService;
     private final NoteQueryService noteQueryService;
     private final UserQueryService userQueryService;
-    private final UserRepository userRepository;
     // 이모지 남기기
     @Operation(summary = "이모지 남기기 API", description = "새로운 이모지를 생성하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             // 에러 상황 정리
+            // 한 사람당 하나만 등록 가능 하게
     })
     @Parameters({
             @Parameter(name = "noteId", description = "이모지를 남길 노트의 아이디입니다."),
@@ -62,10 +62,66 @@ public class EmojiController {
 
         return ApiResponse.of(SuccessStatus._OK, emojiCommandService.postEmoji(note, user, emojiNum)); // DTO로 바꿔서 응답
     }
-    // 이모지 수정
-    
+    // 이모지 수정 - 구현 중
+    @Operation(summary = "이모지 수정 API", description = "이모지를 수정하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            // 에러 상황 정리
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "이모지를 수정할 노트의 아이디입니다."),
+            @Parameter(name = "user", description = "user", hidden = true)
+    })
+    @PatchMapping(value = "/{noteId}")
+    public ApiResponse<EmojiResponseDTO.EmojiClickResult> updateEmoji(@AuthUser long userId,
+                                                                      @PathVariable(name = "noteId")Long noteId,
+                                                                      @RequestParam(name = "emojiNum") Long emojiNum)
+    {
+        Note note = noteQueryService.findNote(noteId);
+        User user = userQueryService.findUser(userId);
+
+        return ApiResponse.of(SuccessStatus._OK, emojiCommandService.postEmoji(note, user, emojiNum)); // DTO로 바꿔서 응답
+    }
     // 이모지 삭제
-    
+    @Operation(summary = "이모지 삭제 API", description = "이모지를 삭제하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            // 에러 상황 정리
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "이모지를 삭제할 노트의 아이디입니다."),
+            @Parameter(name = "user", description = "user", hidden = true)
+    })
+    @DeleteMapping(value = "/{noteId}")
+    public ApiResponse<EmojiResponseDTO.EmojiDeleteResult> deleteEmoji(@AuthUser long userId,
+                                                                      @PathVariable(name = "noteId")Long noteId)
+    {
+        Note note = noteQueryService.findNote(noteId);
+        User user = userQueryService.findUser(userId);
+        EmojiClick emojiClick = emojiQueryService.findByNoteAndUser(note, user);
+
+        return ApiResponse.of(SuccessStatus._OK, emojiCommandService.deleteEmoji(emojiClick)); // DTO로 바꿔서 응답
+    }
     // 이모지 리스트 조회
+    @Operation(summary = "이모지 조회 API", description = "이모지를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            // 에러 상황 정리
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "이모지를 조회할 노트의 아이디입니다."),
+            @Parameter(name = "user", description = "user", hidden = true)
+    })
+    @GetMapping(value = "/{noteId}")
+    public ApiResponse<EmojiResponseDTO.EmojiDeleteResult> getEmoji(@AuthUser long userId,
+                                                                      @PathVariable(name = "noteId")Long noteId)
+    {
+        Note note = noteQueryService.findNote(noteId);
+        User user = userQueryService.findUser(userId);
+        EmojiClick emojiClick = emojiQueryService.findByNoteAndUser(note, user);
+
+
+        return ApiResponse.of(SuccessStatus._OK, emojiCommandService.deleteEmoji(emojiClick)); // DTO로 바꿔서 응답
+    }
 
 }

--- a/src/main/java/com/main/writeRoom/controller/EmojiController.java
+++ b/src/main/java/com/main/writeRoom/controller/EmojiController.java
@@ -1,15 +1,71 @@
 package com.main.writeRoom.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.main.writeRoom.apiPayload.ApiResponse;
+import com.main.writeRoom.apiPayload.status.SuccessStatus;
+import com.main.writeRoom.config.auth.AuthUser;
+import com.main.writeRoom.converter.EmojiConverter;
+import com.main.writeRoom.converter.NoteConverter;
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Emoji;
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.repository.UserRepository;
+import com.main.writeRoom.service.EmojiService.EmojiCommandService;
+import com.main.writeRoom.service.EmojiService.EmojiQueryService;
+import com.main.writeRoom.service.NoteService.NoteQueryService;
+import com.main.writeRoom.service.UserService.UserQueryService;
+import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
+import com.main.writeRoom.web.dto.note.NoteRequestDTO;
+import com.main.writeRoom.web.dto.note.NoteResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/Emoji")
 @Slf4j
 public class EmojiController {
+    private final EmojiQueryService emojiQueryService;
+    private final EmojiCommandService emojiCommandService;
+    private final NoteQueryService noteQueryService;
+    private final UserQueryService userQueryService;
+    private final UserRepository userRepository;
+    // 이모지 남기기
+    @Operation(summary = "이모지 남기기 API", description = "새로운 이모지를 생성하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            // 에러 상황 정리
+    })
+    @Parameters({
+            @Parameter(name = "noteId", description = "이모지를 남길 노트의 아이디입니다."),
+            @Parameter(name = "user", description = "user", hidden = true)
+    })
+    @PostMapping(value = "/{noteId}")
+    public ApiResponse<EmojiResponseDTO.EmojiClickResult> createEmoji(@AuthUser long userId,
+                                                              @PathVariable(name = "noteId")Long noteId,
+                                                              @RequestParam(name = "emojiNum") Long emojiNum)
+    {
+        Note note = noteQueryService.findNote(noteId);
+        User user = userQueryService.findUser(userId);
 
+        return ApiResponse.of(SuccessStatus._OK, emojiCommandService.postEmoji(note, user, emojiNum)); // DTO로 바꿔서 응답
+    }
+    // 이모지 수정
+    
+    // 이모지 삭제
+    
+    // 이모지 리스트 조회
 
 }

--- a/src/main/java/com/main/writeRoom/controller/NoteController.java
+++ b/src/main/java/com/main/writeRoom/controller/NoteController.java
@@ -69,7 +69,7 @@ public class NoteController {
         NoteResponseDTO.PreNoteResult preNote = noteCommandService.createPreNote(room, user, category, noteImg, jsonList);
         Note note = noteCommandService.createNote(preNote);
 
-        return ApiResponse.of(SuccessStatus._OK, NoteConverter.toNoteResult(note));
+        return getNote(note.getId());
     }
 
     @Operation(summary = "노트 조회 API", description = "노트를 조회하는 API입니다.")
@@ -110,7 +110,7 @@ public class NoteController {
         // 사용자의 노트가 아닐 경우 에러
         Category category = categoryQueryService.findCategory(jsonList.getCategoryId());
         Note updatedNote = noteCommandService.updateNoteFields(note, category, noteImg, jsonList);
-        return ApiResponse.of(SuccessStatus._OK, NoteConverter.toNoteResult(updatedNote));
+        return getNote(updatedNote.getId());
     }
 
     @Operation(summary = "노트 삭제 API", description = "노트를 삭제하는 API입니다.") // 되는지 확인 해봐야 하고, 양방향 매핑도 삭제 해야 함. 이모지 태그 등

--- a/src/main/java/com/main/writeRoom/controller/NoteController.java
+++ b/src/main/java/com/main/writeRoom/controller/NoteController.java
@@ -72,23 +72,21 @@ public class NoteController {
         return ApiResponse.of(SuccessStatus._OK, NoteConverter.toNoteResult(note));
     }
 
-    // 노트 아이디 받아서 노트 조회
     @Operation(summary = "노트 조회 API", description = "노트를 조회하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             // 존재 하지 않는 노트일 때 에러
-            // 노트를 포함한 룸의 사용자가 아닐 경우 에러
+            // 조회에서도 룸 안의 사람만 조회 가능한가? 필요하면 조건 추가.
+            // 노트 생성 수정 시 바로 노트 조회 반환해도 좋을 듯 함.
     })
     @Parameters({
             @Parameter(name = "noteId", description = "조회할 노트의 아이디입니다."),
-            @Parameter(name = "user", description = "user", hidden = true)
     })
     @GetMapping("/notes/{noteId}")
-    public ApiResponse<NoteResponseDTO.NoteResult> getNote(@PathVariable(name = "noteId")Long noteId, @AuthUser long userId) {
+    public ApiResponse<NoteResponseDTO.NoteResult> getNote(@PathVariable(name = "noteId")Long noteId) {
 
         Note note = noteQueryService.findNote(noteId);
-        // 해당 노트가 존재하는 룸의 사용자가 아닐 경우 에러 발생
-        return ApiResponse.of(SuccessStatus._OK, noteCommandService.getNote(note));
+        return ApiResponse.of(SuccessStatus._OK, noteQueryService.getNote(note)); // 이거 노트 쿼리에서 서비스 임플 만들어야 하는거 아닌가
     }
 
     // 조회 페이지를 먼저 들어가서 수정 해야 함. 수정시에는 노트 아이디와 수정 컨텐츠를 같이 받을 것

--- a/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
@@ -4,6 +4,10 @@ import com.main.writeRoom.domain.Emoji;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.EmojiClick;
 import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +26,14 @@ public class EmojiConverter {
         return EmojiResponseDTO.EmojiClickResult.builder()
                 .emojiClickId(emojiClick.getId())
                 .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static EmojiResponseDTO.EmojiUpdateResult toEmojiUpdateResult(Emoji emoji) {
+        return EmojiResponseDTO.EmojiUpdateResult.builder()
+                .emojiId(emoji.getId())
+                .emojiNum(emoji.getEmojiNum())
+                .updatedAT(emoji.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
@@ -1,0 +1,28 @@
+package com.main.writeRoom.converter;
+
+import com.main.writeRoom.domain.Emoji;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class EmojiConverter {
+
+    public static Emoji toEmoji(User user, Long emojiNum) {
+
+        return Emoji.builder()
+                .user(user)
+                .emojiNum(emojiNum)
+                .build();
+    }
+
+    public static EmojiResponseDTO.EmojiClickResult toEmojiClickResult(EmojiClick emojiClick) {
+
+        return EmojiResponseDTO.EmojiClickResult.builder()
+                .emojiClickId(emojiClick.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/EmojiConverter.java
@@ -25,4 +25,11 @@ public class EmojiConverter {
                 .build();
     }
 
+    public static EmojiResponseDTO.EmojiDeleteResult toEmojiDeleteResult(EmojiClick emojiClick) {
+
+        return EmojiResponseDTO.EmojiDeleteResult.builder()
+                .emojiClickId(emojiClick.getId())
+                .build();
+    }
+
 }

--- a/src/main/java/com/main/writeRoom/converter/NoteConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/NoteConverter.java
@@ -57,7 +57,7 @@ public static NoteResponseDTO.RoomResult toRoomResultDTO(Room room, Page<Note> n
                 .updatedAt(note.getUpdatedAt())
                 .noteId(note.getId())
                 .categoryName(note.getCategory().getName())
-                .emojiClickList(new ArrayList<>())
+                .emojiList(new ArrayList<>())
                 .writer(note.getUser().getName())
                 .tagList(new ArrayList<>())
                 .build();

--- a/src/main/java/com/main/writeRoom/domain/Emoji.java
+++ b/src/main/java/com/main/writeRoom/domain/Emoji.java
@@ -8,11 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity(name = "Emoji")
 @Getter
@@ -23,6 +19,7 @@ public class Emoji extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Setter
     private Long emojiNum;
 
     @ManyToOne

--- a/src/main/java/com/main/writeRoom/domain/Emoji.java
+++ b/src/main/java/com/main/writeRoom/domain/Emoji.java
@@ -23,8 +23,7 @@ public class Emoji extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
-    private String image;
+    private Long emojiNum;
 
     @ManyToOne
     @JoinColumn(name = "user")

--- a/src/main/java/com/main/writeRoom/domain/mapping/EmojiClick.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/EmojiClick.java
@@ -3,14 +3,20 @@ package com.main.writeRoom.domain.mapping;
 import com.main.writeRoom.domain.Emoji;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.*;
 
 @Entity(name = "EmojiClick")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class EmojiClick {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,5 +29,9 @@ public class EmojiClick {
     @ManyToOne
     @JoinColumn(name = "note")
     private Note note;
+
+    @ManyToOne
+    @JoinColumn(name = "user")
+    private User user;
 
 }

--- a/src/main/java/com/main/writeRoom/domain/mapping/EmojiClick.java
+++ b/src/main/java/com/main/writeRoom/domain/mapping/EmojiClick.java
@@ -4,12 +4,7 @@ import com.main.writeRoom.domain.Emoji;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity(name = "EmojiClick")

--- a/src/main/java/com/main/writeRoom/handler/EmojiHandler.java
+++ b/src/main/java/com/main/writeRoom/handler/EmojiHandler.java
@@ -1,0 +1,8 @@
+package com.main.writeRoom.handler;
+
+import com.main.writeRoom.apiPayload.code.BaseErrorCode;
+import com.main.writeRoom.apiPayload.handler.GeneralException;
+
+public class EmojiHandler extends GeneralException {
+    public EmojiHandler(BaseErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/main/writeRoom/repository/EmojiClickRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/EmojiClickRepository.java
@@ -1,7 +1,14 @@
 package com.main.writeRoom.repository;
 
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.EmojiClick;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface EmojiClickRepository extends JpaRepository<EmojiClick, Long> {
+    Optional<EmojiClick> findByNoteAndUser(Note note, User user);
+
 }

--- a/src/main/java/com/main/writeRoom/repository/EmojiClickRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/EmojiClickRepository.java
@@ -1,0 +1,7 @@
+package com.main.writeRoom.repository;
+
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmojiClickRepository extends JpaRepository<EmojiClick, Long> {
+}

--- a/src/main/java/com/main/writeRoom/repository/EmojiRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/EmojiRepository.java
@@ -1,0 +1,7 @@
+package com.main.writeRoom.repository;
+
+import com.main.writeRoom.domain.Emoji;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmojiRepository extends JpaRepository<Emoji, Long> {
+}

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
@@ -7,4 +7,7 @@ import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
 
 public interface EmojiCommandService {
     EmojiResponseDTO.EmojiClickResult postEmoji(Note note, User user, Long emojiNum);
+
+    EmojiResponseDTO.EmojiDeleteResult deleteEmoji(EmojiClick emojiClick);
+
 }

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
@@ -1,0 +1,10 @@
+package com.main.writeRoom.service.EmojiService;
+
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
+
+public interface EmojiCommandService {
+    EmojiResponseDTO.EmojiClickResult postEmoji(Note note, User user, Long emojiNum);
+}

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandService.java
@@ -7,6 +7,7 @@ import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
 
 public interface EmojiCommandService {
     EmojiResponseDTO.EmojiClickResult postEmoji(Note note, User user, Long emojiNum);
+    EmojiResponseDTO.EmojiUpdateResult updateEmoji(Note note, User user, EmojiClick emojiClick, Long emojiNum);
 
     EmojiResponseDTO.EmojiDeleteResult deleteEmoji(EmojiClick emojiClick);
 

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
@@ -1,0 +1,38 @@
+package com.main.writeRoom.service.EmojiService;
+
+import com.main.writeRoom.converter.EmojiConverter;
+import com.main.writeRoom.domain.Emoji;
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.repository.EmojiClickRepository;
+import com.main.writeRoom.repository.EmojiRepository;
+import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmojiCommandServiceImpl implements EmojiCommandService{
+
+    private final EmojiRepository emojiRepository;
+    private final EmojiClickRepository emojiClickRepository;
+
+    @Transactional
+    public EmojiResponseDTO.EmojiClickResult postEmoji(Note note, User user, Long emojiNum) {
+
+        Emoji emoji = EmojiConverter.toEmoji(user, emojiNum);
+        emojiRepository.save(emoji);
+
+        EmojiClick emojiClick = EmojiClick.builder()
+                .emoji(emoji)
+                .user(user)
+                .note(note)
+                .build();
+        emojiClickRepository.save(emojiClick);
+
+        return EmojiConverter.toEmojiClickResult(emojiClick);
+    }
+}

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
@@ -14,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,6 +24,11 @@ public class EmojiCommandServiceImpl implements EmojiCommandService{
 
     @Transactional
     public EmojiResponseDTO.EmojiClickResult postEmoji(Note note, User user, Long emojiNum) {
+
+        // 재등록 방지 에러 처리
+        if(emojiClickRepository.findByNoteAndUser(note, user).isPresent())
+            throw new EmojiHandler(ErrorStatus.EMOJI_REPOST);
+
 
         Emoji emoji = EmojiConverter.toEmoji(user, emojiNum);
         emojiRepository.save(emoji);
@@ -38,6 +41,16 @@ public class EmojiCommandServiceImpl implements EmojiCommandService{
         emojiClickRepository.save(emojiClick);
 
         return EmojiConverter.toEmojiClickResult(emojiClick);
+    }
+
+    @Transactional
+    public EmojiResponseDTO.EmojiUpdateResult updateEmoji(Note note, User user, EmojiClick emojiClick,Long emojiNum) {
+
+        Emoji emoji = emojiClick.getEmoji();
+        emoji.setEmojiNum(emojiNum);
+        emojiRepository.save(emoji);
+
+        return EmojiConverter.toEmojiUpdateResult(emoji);
     }
 
     @Transactional

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiCommandServiceImpl.java
@@ -1,16 +1,20 @@
 package com.main.writeRoom.service.EmojiService;
 
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.converter.EmojiConverter;
 import com.main.writeRoom.domain.Emoji;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.handler.EmojiHandler;
 import com.main.writeRoom.repository.EmojiClickRepository;
 import com.main.writeRoom.repository.EmojiRepository;
 import com.main.writeRoom.web.dto.emoji.EmojiResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,4 +39,17 @@ public class EmojiCommandServiceImpl implements EmojiCommandService{
 
         return EmojiConverter.toEmojiClickResult(emojiClick);
     }
+
+    @Transactional
+    public EmojiResponseDTO.EmojiDeleteResult deleteEmoji(EmojiClick emojiClick) {
+
+            Emoji emoji = emojiClick.getEmoji();
+            emojiRepository.deleteById(emoji.getId());
+            emojiClickRepository.deleteById(emojiClick.getId());
+
+            return EmojiConverter.toEmojiDeleteResult(emojiClick);
+
+    }
+
+
 }

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryService.java
@@ -1,4 +1,11 @@
 package com.main.writeRoom.service.EmojiService;
 
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+
+import java.util.Optional;
+
 public interface EmojiQueryService {
+    EmojiClick findByNoteAndUser(Note note, User user);
 }

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryService.java
@@ -1,0 +1,4 @@
+package com.main.writeRoom.service.EmojiService;
+
+public interface EmojiQueryService {
+}

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryServiceImpl.java
@@ -1,11 +1,31 @@
 package com.main.writeRoom.service.EmojiService;
 
+import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.domain.Category;
+import com.main.writeRoom.domain.Note;
+import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.EmojiClick;
+import com.main.writeRoom.handler.EmojiHandler;
+import com.main.writeRoom.repository.EmojiClickRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EmojiQueryServiceImpl implements EmojiQueryService{
+    private final EmojiClickRepository emojiClickRepository;
+    public EmojiClick findByNoteAndUser(Note note, User user) {
+        return emojiClickRepository.findByNoteAndUser(note, user).orElseThrow(() -> new EmojiHandler(ErrorStatus.EMOJI_NOT_FOUNT));
+    }
+
+
+    /*public List<Note> findNoteForCategoryAndRoom(Category category, Room room) {
+        return noteRepository.findAllByCategoryAndRoom(category, room);
+    }*/
 }

--- a/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/EmojiService/EmojiQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package com.main.writeRoom.service.EmojiService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmojiQueryServiceImpl implements EmojiQueryService{
+}

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteCommandService.java
@@ -10,8 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface NoteCommandService {
     public NoteResponseDTO.PreNoteResult createPreNote(Room room, User user, Category category, MultipartFile noteImg, NoteRequestDTO.createNoteDTO request);
-    public NoteResponseDTO.NoteResult getNote(Note note);
-
     public Note createNote(NoteResponseDTO.PreNoteResult preNoteResult);
     public Note updateNoteFields(Note existingNote, Category category, MultipartFile noteImg, NoteRequestDTO.patchNoteDTO request);
 

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteCommandServiceImpl.java
@@ -135,17 +135,6 @@ public class NoteCommandServiceImpl implements NoteCommandService{
 
         return noteRepository.save(updatedNote);
     }
-    
-    @Transactional
-    public NoteResponseDTO.NoteResult getNote(Note note) {
-        
-        // 컨버터에서 노트 빌드
-        // 서비스에서 양방향 매핑
-        NoteResponseDTO.NoteResult noteResult = NoteConverter.toNoteResult(note);
-
-        return noteResult;
-
-    }
 
     @Transactional
     public NoteResponseDTO.NoteResult deleteNote(Long roomId, Long noteId) {

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryService.java
@@ -1,17 +1,21 @@
 package com.main.writeRoom.service.NoteService;
 
+import com.main.writeRoom.converter.NoteConverter;
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
 import java.util.List;
 
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.web.dto.note.NoteResponseDTO;
 import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface NoteQueryService {
     Page<Note> findNoteForRoomAndCategory(Category category, Room room, Integer page);
     List<Note> findNoteForCategoryAndRoom(Category category, Room room);
     Page<Note> getNoteListForRoom(Room room, Integer page);
     Note findNote(Long noteId);
+    public NoteResponseDTO.NoteResult getNote(Note note);
     public Page<Note> findNoteListForRoomAndUser(Room room, User user, Integer page);
 }

--- a/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/NoteService/NoteQueryServiceImpl.java
@@ -1,13 +1,24 @@
 package com.main.writeRoom.service.NoteService;
 
 import com.main.writeRoom.apiPayload.status.ErrorStatus;
+import com.main.writeRoom.converter.NoteConverter;
 import com.main.writeRoom.domain.Category;
 import com.main.writeRoom.domain.Note;
 import com.main.writeRoom.domain.Room;
+import com.main.writeRoom.domain.Tag;
 import com.main.writeRoom.domain.User.User;
+import com.main.writeRoom.domain.mapping.NoteTag;
 import com.main.writeRoom.handler.NoteHandler;
 import com.main.writeRoom.repository.NoteRepository;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.main.writeRoom.repository.NoteTagRepository;
+import com.main.writeRoom.repository.TagRepository;
+import com.main.writeRoom.web.dto.note.NoteResponseDTO;
+import com.main.writeRoom.web.dto.tag.TagResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NoteQueryServiceImpl implements NoteQueryService{
     private final NoteRepository noteRepository;
+    private final NoteTagRepository noteTagRepository;
+    private final TagRepository tagRepository;
 
     public List<Note> findNoteForCategoryAndRoom(Category category, Room room) {
         return noteRepository.findAllByCategoryAndRoom(category, room);
@@ -32,6 +45,26 @@ public class NoteQueryServiceImpl implements NoteQueryService{
     public Note findNote(Long noteId) {
         return noteRepository.findById(noteId)
                 .orElseThrow(() -> new NoteHandler(ErrorStatus.NOTE_NOT_FOUND));
+    }
+
+    @Transactional
+    public NoteResponseDTO.NoteResult getNote(Note note) {
+
+        NoteResponseDTO.NoteResult noteResult = NoteConverter.toNoteResponseDTO(note);
+
+        // NoteTag 리스트에서 Tag 객체를 가져오고, Note 객체의 참조를 제거하여 순환 참조 방지
+        List<TagResponseDTO.TagList> tagDTOList = note.getNoteTagList().stream()
+                .map(NoteTag::getTag)
+                .filter(Objects::nonNull)
+                .map(tag -> new TagResponseDTO.TagList(tag.getId(), tag.getContent())) // TagDTO는 순환 참조가 없는 DTO
+                .toList();
+
+        // NoteResult에 TagDTO 리스트를 추가
+        noteResult.getTagList().addAll(tagDTOList);
+
+        return noteResult;
+
+        // 노트에 이모지 리스트 삽입
     }
     public Page<Note> findNoteForRoomAndCategory(Category category, Room room, Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10);

--- a/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
@@ -18,4 +18,11 @@ public class EmojiResponseDTO {
         LocalDateTime createdAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmojiDeleteResult {
+        Long emojiClickId;
+    }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
@@ -1,0 +1,21 @@
+package com.main.writeRoom.web.dto.emoji;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class EmojiResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmojiClickResult {
+        Long emojiClickId;
+        LocalDateTime createdAt;
+    }
+
+}

--- a/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/emoji/EmojiResponseDTO.java
@@ -25,4 +25,14 @@ public class EmojiResponseDTO {
     public static class EmojiDeleteResult {
         Long emojiClickId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmojiUpdateResult {
+        Long emojiId;
+        Long emojiNum;
+        LocalDateTime updatedAT;
+    }
 }

--- a/src/main/java/com/main/writeRoom/web/dto/note/NoteResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/note/NoteResponseDTO.java
@@ -7,6 +7,8 @@ import com.main.writeRoom.domain.mapping.EmojiClick;
 import com.main.writeRoom.web.dto.tag.TagResponseDTO;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,7 +66,7 @@ public class NoteResponseDTO {
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
         List<TagResponseDTO.TagList> tagList;
-        List<EmojiClick> emojiClickList; // EmojiResponseDTO로 변경
+        List<Emoji> emojiList; // EmojiResponseDTO로 변경할지 고민
 
     }
 }


### PR DESCRIPTION
노트 생성 API, 노트 수정 API 반환 시 노트 조회 API 호출 하도록 업데이트 했습니다.



이모지 조회를 포함하여 노트 조회 API 한번 더 업데이트 해야 합니다.
노트 삭제 API 구현 해야 합니다.