### PR TITLE
[FEAT] 챌린지 관련 기능 구현 및 수정

### DIFF
--- a/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/main/writeRoom/apiPayload/status/ErrorStatus.java
@@ -41,7 +41,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DEADLINE_OUT_RANGE(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "챌린지 마감 날짜 범위를 벗어났습니다."),
     GOALS_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "챌린지 목표량이 없습니다."),
     NOT_PARTICIPATE(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "해당 챌린지에 사용자가 참여하지 않았습니다."),
-    CHALLENGE_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "룸과 회원에 해당하는 챌린지가 없습니다.")
+    CHALLENGE_NOTFOUND(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "룸과 회원에 해당하는 챌린지가 없습니다."),
+    ALREADY_PROGRESS(HttpStatus.BAD_REQUEST, "CHALLENGE4008", "이미 진행 중인 챌린지가 있습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -106,7 +106,21 @@ public class ChallengeController {
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toUserList(userList));
     }
     //같은 룸에 있는 참여 가능한 회원 조회 - 목표량
-
+    @GetMapping("/challenge-goals/create/users")
+    @Operation(summary = "챌린지 목표량 생성 시 참여 가능한 회원 조회 API", description = "목표량 달성하기 화면에서 챌린지 목표량의 참여자를 등록할 때, 참여 가능 회원을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ROOM4001", description = "룸이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @Parameters({
+            @Parameter(name = "roomId", description = "챌린지가 진행될 룸의 식별자를 입력하세요."),
+    })
+    public ApiResponse<ChallengeResponseDTO.UserList> getGoalsUsers(@RequestParam(name = "roomId") Long roomId) {
+        List<ChallengeResponseDTO.UserDTO> userList = goalsQueryService.findGoalsUsers(roomQueryService.findRoom(roomId)).stream()
+                .map(user -> ChallengeConverter.toUserDTO(user)).collect(Collectors.toList());
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toUserList(userList));
+    }
 
     //챌린지 루틴 조회
     @GetMapping("/challenge-routines/{roomId}")

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -26,6 +26,7 @@ import com.main.writeRoom.validation.annotation.PageLessNull;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
 import com.main.writeRoom.web.dto.note.NoteResponseDTO;
+import com.main.writeRoom.web.dto.room.RoomResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -72,7 +73,7 @@ public class ChallengeController {
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4004", description = "챌린지 마감 날짜의 범위를 벗어났습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4008", description = "챌린지 마감 날짜의 범위를 벗어났습니다.",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4008", description = "이미 진행 중인 챌린지가 있습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
     })
     @Parameters({
@@ -87,6 +88,25 @@ public class ChallengeController {
         ChallengeRoutine challengeRoutine = routineCommandService.create(roomId, request);
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toCreateChallengeRoutineResultDTO(challengeRoutine));
     }
+
+    //같은 룸에 있는 참여 가능한 회원 조회 - 루틴
+    @GetMapping("/challenge-routines/create/users")
+    @Operation(summary = "챌린지 루틴 생성 시 참여 가능한 회원 조회 API", description = "루틴 만들기 화면에서 챌린지 루틴의 참여자를 등록할 때, 참여 가능 회원을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ROOM4001", description = "룸이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @Parameters({
+            @Parameter(name = "roomId", description = "챌린지가 진행될 룸의 식별자를 입력하세요."),
+    })
+    public ApiResponse<ChallengeResponseDTO.UserList> getRoutineUsers(@RequestParam(name = "roomId") Long roomId) {
+        List<ChallengeResponseDTO.UserDTO> userList = routineQueryService.findRoutineUsers(roomQueryService.findRoom(roomId)).stream()
+                .map(user -> ChallengeConverter.toUserDTO(user)).collect(Collectors.toList());
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toUserList(userList));
+    }
+    //같은 룸에 있는 참여 가능한 회원 조회 - 목표량
+
 
     //챌린지 루틴 조회
     @GetMapping("/challenge-routines/{roomId}")
@@ -193,7 +213,7 @@ public class ChallengeController {
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4004", description = "챌린지 마감 날짜의 범위를 벗어났습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4008", description = "챌린지 마감 날짜의 범위를 벗어났습니다.",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4008", description = "이미 진행 중인 챌린지가 있습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
     })
     @Parameters({

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -236,6 +236,27 @@ public class ChallengeController {
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, achieveCount));
     }
 
+    //다른 참여자꺼 챌린지 목표량 조회
+    @GetMapping("/challenge-goals/{participantsId}/{challengeId}")
+    @Operation(summary = "다른 참여자 챌린지 목표량 조회 API", description = "목표량 달성하기 진행화면에서 다른 참여자의 챌린지 목표량 진행화면을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "사용자가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4005", description = "챌린지 목표량이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @Parameters({
+            @Parameter(name = "participantsId", description = "다른 참여자의 회원 식별자를 입력하세요."),
+            @Parameter(name = "challengeId", description = "챌린지 목표량 식별자를 입력하세요.")
+    })
+    public ApiResponse<ChallengeResponseDTO.ChallengeGoalsDTO> getParticipantsGoals(@PathVariable(name = "participantsId") Long participantsId, @PathVariable(name = "challengeId") Long challengeId) {
+        User user1 = userQueryService.findUser(participantsId);
+        ChallengeGoals goals = goalsQueryService.findGoals(challengeId);
+        Integer achieveCount = goalsQueryService.findAchieveNote(user1, goals);
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, achieveCount));
+    }
+
     //챌린지 목표량 포기
     @PatchMapping("challenge-goals/give-up/{challengeId}")
     @Operation(summary = "챌린지 목표량 포기 API", description = "챌린지 포기하기 팝업에서 챌린지 목표량을 포기하는 API입니다.")

--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -115,6 +115,27 @@ public class ChallengeController {
         return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeRoutineDTO(user1, routine, noteList));
     }
 
+    //다른 참여자꺼 챌린지 루틴 조회
+    @GetMapping("/challenge-routines/{participantsId}/{challengeId}")
+    @Operation(summary = "다른 참여자 챌린지 루틴 조회 API", description = "루틴 만들기 챌린지 진행화면에서 다른 참여자의 챌린지 루틴 진행화면을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "사용자가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4001", description = "챌린지 루틴이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class)))
+    })
+    @Parameters({
+            @Parameter(name = "participantsId", description = "다른 참여자의 회원 식별자를 입력하세요."),
+            @Parameter(name = "challengeId", description = "챌린지 루틴 식별자를 입력하세요.")
+    })
+    public ApiResponse<ChallengeResponseDTO.ChallengeRoutineDTO> getParticipantsRoutine(@PathVariable(name = "participantsId") Long participantsId, @PathVariable(name = "challengeId") Long challengeId) {
+        User user1 = userQueryService.findUser(participantsId);
+        ChallengeRoutine routine = routineQueryService.findRoutine(challengeId);
+        List<ChallengeResponseDTO.NoteDTO> noteList = routineQueryService.findNoteDate(user1, routine);
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeRoutineDTO(user1, routine, noteList));
+    }
+
     //챌린지 루틴 달성 노트 조회
     @GetMapping("/challenge-routines/{roomId}/notes")
     @Operation(summary = "챌린지 루틴 달성 노트 조회 API", description = "루틴 만들기 챌린지 진행화면에서 챌린지 루틴 달성 스탬프를 눌렀을 때 해당 날짜에 작성된 200자 이상의 노트들이 조회되는 API입니다.")

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -216,4 +216,11 @@ public class ChallengeConverter {
                 .challengeStatus(goalsParticipation.getChallengeStatus())
                 .build();
     }
+
+    //참여가능한 회원 목록 dto로 변환
+    public static ChallengeResponseDTO.UserList toUserList(List<ChallengeResponseDTO.UserDTO> userDTOList) {
+        return ChallengeResponseDTO.UserList.builder()
+                .userList(userDTOList)
+                .build();
+    }
 }

--- a/src/main/java/com/main/writeRoom/repository/RoomParticipationRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/RoomParticipationRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RoomParticipationRepository extends JpaRepository<RoomParticipation, Long> {
     Page<RoomParticipation> findAllByUser(User user, PageRequest pageRequest);
@@ -15,4 +17,5 @@ public interface RoomParticipationRepository extends JpaRepository<RoomParticipa
     RoomParticipation findByRoomAndUser(Room room, User user);
     void deleteByRoomAndUser(Room room, User user);
     boolean existsByRoomAndUser(Room room, User user);
+    List<RoomParticipation> findByRoom(Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandService.java
@@ -12,5 +12,4 @@ public interface ChallengeGoalsCommandService {
     public ChallengeGoals create(Long roomId, ChallengeRequestDTO.ChallengeGoalsDTO request);
     public void deadlineRangeNull(LocalDate startDate, LocalDate deadline);
     public ChallengeGoalsParticipation giveUP(Long userId, Long challengeGoalsId);
-    public void isStatusProgress(User user, ChallengeGoals goals);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
@@ -91,11 +91,4 @@ public class ChallengeGoalsCommandServiceImpl implements ChallengeGoalsCommandSe
 
         return goalsParticipation;
     }
-
-    @Override
-    public void isStatusProgress(User user, ChallengeGoals goals) {
-        if (goalsQueryService.findGoalsParticipation(user, goals).getChallengeStatus() != ChallengeStatus.PROGRESS) {
-            throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
-        }
-    }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsCommandServiceImpl.java
@@ -13,6 +13,7 @@ import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import com.main.writeRoom.handler.ChallengeHandler;
 import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
 import com.main.writeRoom.repository.ChallengeGoalsRepository;
+import com.main.writeRoom.repository.RoomParticipationRepository;
 import com.main.writeRoom.service.RoomService.RoomQueryService;
 import com.main.writeRoom.service.UserService.UserQueryService;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
@@ -17,4 +17,6 @@ public interface ChallengeGoalsQueryService {
 
     public ChallengeGoalsParticipation findProgressGoalsParticipation(User user, Room room);
     public List<ChallengeGoalsParticipation> findByChallengeStatus(ChallengeStatus challengeStatus);
+
+    public List<User> findGoalsUsers(Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
@@ -11,12 +11,14 @@ import com.main.writeRoom.handler.ChallengeHandler;
 import com.main.writeRoom.repository.ChallengeGoalsParticipationRepository;
 import com.main.writeRoom.repository.ChallengeGoalsRepository;
 import com.main.writeRoom.repository.NoteRepository;
+import com.main.writeRoom.service.RoomParticipationService.RoomParticipationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,6 +27,7 @@ public class ChallengeGoalsQueryServiceImpl implements ChallengeGoalsQueryServic
     private final ChallengeGoalsRepository goalsRepository;
     private final NoteRepository noteRepository;
     private final ChallengeGoalsParticipationRepository goalsParticipationRepository;
+    private final RoomParticipationService roomParticipationService;
 
     @Override
     public ChallengeGoals findGoals(Long challengeId) {
@@ -53,4 +56,13 @@ public class ChallengeGoalsQueryServiceImpl implements ChallengeGoalsQueryServic
     public List<ChallengeGoalsParticipation> findByChallengeStatus(ChallengeStatus challengeStatus) {
         return goalsParticipationRepository.findByChallengeStatus(challengeStatus);
     }
+
+    @Override
+    public List<User> findGoalsUsers(Room room) {
+        List<User> userList = roomParticipationService.findRoomUserList(room).stream()
+                .filter(user -> findProgressGoalsParticipation(user, room) == null) //진행 중인 참여자를 조회했을 때 null이 반환되는 참여자로 필터링
+                .collect(Collectors.toList());
+        return userList;
+    }
+
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandService.java
@@ -14,5 +14,4 @@ public interface ChallengeRoutineCommandService {
     public void deadlineRange(LocalDate startDate, LocalDate deadline);
 
     public ChallengeRoutineParticipation giveUp(Long userId, Long challengeRoutineId);
-    public void isStatusProgress(User user, ChallengeRoutine routine);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineCommandServiceImpl.java
@@ -92,11 +92,4 @@ public class ChallengeRoutineCommandServiceImpl implements ChallengeRoutineComma
 
         return routineParticipation;
     }
-
-    @Override
-    public void isStatusProgress(User user, ChallengeRoutine routine) {
-        if (routineQueryService.findRoutineParticipation(user, routine).getChallengeStatus() != ChallengeStatus.PROGRESS) {
-            throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
-        }
-    }
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryService.java
@@ -18,4 +18,5 @@ public interface ChallengeRoutineQueryService {
     public ChallengeRoutineParticipation findProgressRoutineParticipation(User user, Room room);
 
     public List<ChallengeRoutineParticipation> findByChallengeStatus(ChallengeStatus challengeStatus);
+    public List<User> findRoutineUsers(Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
@@ -10,6 +10,7 @@ import com.main.writeRoom.domain.mapping.ChallengeRoutineParticipation;
 import com.main.writeRoom.domain.mapping.ChallengeStatus;
 import com.main.writeRoom.handler.ChallengeHandler;
 import com.main.writeRoom.repository.*;
+import com.main.writeRoom.service.RoomParticipationService.RoomParticipationServiceImpl;
 import com.main.writeRoom.service.UserService.UserQueryService;
 import com.main.writeRoom.web.dto.challenge.ChallengeRequestDTO;
 import com.main.writeRoom.web.dto.challenge.ChallengeResponseDTO;
@@ -30,6 +31,7 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
     private final NoteRepository noteRepository;
     private final UserQueryService userQueryService;
     private final ChallengeRoutineParticipationRepository routineParticipationRepository;
+    private final RoomParticipationServiceImpl roomParticipationService;
 
     @Override
     public ChallengeRoutine findRoutine(Long challengeId) {
@@ -62,4 +64,12 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
         return routineParticipationRepository.findByChallengeStatus(challengeStatus);
     }
 
+    //참여 가능한 회원 찾기
+    @Override
+    public List<User> findRoutineUsers(Room room) {
+        List<User> userList = roomParticipationService.findRoomUserList(room).stream()
+                .filter(user -> findProgressRoutineParticipation(user, room) == null) //진행 중인 참여자를 조회했을 때 null이 반환되는 참여자로 필터링
+                .collect(Collectors.toList());
+        return userList;
+    }
 }

--- a/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationService.java
+++ b/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationService.java
@@ -3,8 +3,11 @@ package com.main.writeRoom.service.RoomParticipationService;
 import com.main.writeRoom.domain.Room;
 import com.main.writeRoom.domain.User.User;
 
+import java.util.List;
+
 public interface RoomParticipationService {
     void leaveRoom(Room room, User user);
     void outRoom(Room room, User user, User outUser);
     void updateAuthority(Room room, User user, User updateUser, String authority);
+    public List<User> findRoomUserList(Room room);
 }

--- a/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationServiceImpl.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,5 +43,12 @@ public class RoomParticipationServiceImpl implements RoomParticipationService {
         }
         RoomParticipation updateRoom = roomParticipationRepository.findByRoomAndUser(room, updateUser);
         updateRoom.updateAuthority(authority);
+    }
+
+    public List<User> findRoomUserList(Room room) {
+        List<User> userList = roomParticipationRepository.findByRoom(room).stream()
+                .map(roomParticipation -> roomParticipation.getUser())
+                .collect(Collectors.toList());
+        return userList;
     }
 }

--- a/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/RoomParticipationService/RoomParticipationServiceImpl.java
@@ -45,6 +45,7 @@ public class RoomParticipationServiceImpl implements RoomParticipationService {
         updateRoom.updateAuthority(authority);
     }
 
+    @Override
     public List<User> findRoomUserList(Room room) {
         List<User> userList = roomParticipationRepository.findByRoom(room).stream()
                 .map(roomParticipation -> roomParticipation.getUser())

--- a/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
+++ b/src/main/java/com/main/writeRoom/web/dto/challenge/ChallengeResponseDTO.java
@@ -26,6 +26,15 @@ public class ChallengeResponseDTO {
         Long challengeId;
     }
 
+    //참여 가능한 회원 목록 조회
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserList {
+        List<UserDTO> userList;
+    }
+
     //2. 챌린지 루틴 조회
     @Builder
     @Getter


### PR DESCRIPTION
### 이슈
- #105 

### 작업 내용
 - 챌린지 조회 api의 path variable을 challengeId -> roomId로 수정
 - 챌린지 생성api에서 PROGRESS인 챌린지가 이미 존재하면 중복 생성 막기
 - 다른 참여자의 챌린지 루틴 조회 api
 - 다른 참여자의 챌린지 목표량 조회 api
 - 루틴 참여 가능한 회원 조회 api
 - 목표량 참여 가능한 회원 조회 api