### PR TITLE
[FEAT] 비밀번호 재설정 API 구현 #101

### DIFF
--- a/src/main/java/com/main/writeRoom/controller/AuthController.java
+++ b/src/main/java/com/main/writeRoom/controller/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
     }
 
-    @Operation(summary = "비밀번호 재설정 API", description = "비밀번호 재설정 API이며, 유저가 재설정 버튼 url에 토큰을 같이 담았습니다.")
+    @Operation(summary = "로그인 시 비밀번호 재설정 API", description = "로그인 시 비밀번호 재설정 API이며, 유저가 재설정 버튼 url에 토큰을 같이 담았습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TOKEN4001", description = "재설정 토큰이 잘못되었습니다.",

--- a/src/main/java/com/main/writeRoom/controller/AuthController.java
+++ b/src/main/java/com/main/writeRoom/controller/AuthController.java
@@ -55,10 +55,13 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
     }
 
-    @Operation(summary = "로그인 시 비밀번호 재설정 API", description = "로그인 시 비밀번호 재설정 API이며, 유저가 재설정 버튼 url에 토큰을 같이 담았습니다.")
+    @Operation(summary = "비밀번호 재설정 API", description = "로그인 시 비밀번호 재설정 API이며, 유저가 재설정 버튼 url에 토큰을 같이 담았습니다. "
+            + "type 을 입력해주세요. ex) 1. email // 2. pwd")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TOKEN4001", description = "재설정 토큰이 잘못되었습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "이미 존재하는 이메일입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
     })
     @Parameters({
@@ -66,8 +69,9 @@ public class AuthController {
     })
     @PostMapping("/resetPwd")
     public ApiResponse<UserResponseDTO.CustomUserInfo> resetPwd(@RequestBody UserRequestDTO.ResetPassword request,
-                                                                @RequestParam(name = "token")String resetToken) {
-        User user = authService.resetPwd(request, resetToken);
+                                                                @RequestParam(name = "token")String resetToken,
+                                                                @RequestParam(name= "type")String type) {
+        User user = authService.resetPwd(request, resetToken, type);
         return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
     }
 }

--- a/src/main/java/com/main/writeRoom/controller/UserController.java
+++ b/src/main/java/com/main/writeRoom/controller/UserController.java
@@ -15,9 +15,12 @@ import com.main.writeRoom.service.UserService.UserQueryService;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
 import com.main.writeRoom.web.dto.user.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -71,9 +74,30 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "비밀번호가 일치하지 않습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
     })
+    @Parameters({
+            @Parameter(name = "user", description = "user", hidden = true),
+    })
     @PatchMapping("/password")
     public ApiResponse<UserResponseDTO.CustomUserInfo> updatedPassword(@AuthUser long userId, @RequestBody UserRequestDTO.UpdatedPassword request) {
         User user = userCommandService.updatedPassword(userId, request);
+        return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
+    }
+
+    @Operation(summary = "유저 이메일 주소 변경 API", description = "유저의 이메일 주소 변경 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "사용자가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "비밀번호가 일치하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @Parameters({
+            @Parameter(name = "user", description = "user", hidden = true),
+    })
+    @PatchMapping("/email")
+    public ApiResponse<UserResponseDTO.CustomUserInfo> updatedEmail(@AuthUser long userId, @RequestBody UserRequestDTO.ResetPasswordForEmail request)
+            throws MessagingException {
+        User user = userCommandService.updatedEmail(userId, request);
         return ApiResponse.of(SuccessStatus._OK, UserConverter.CustomUserInfoResultDTO(user));
     }
 }

--- a/src/main/java/com/main/writeRoom/converter/UserConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/UserConverter.java
@@ -1,5 +1,6 @@
 package com.main.writeRoom.converter;
 
+import com.main.writeRoom.domain.User.ExistedEmail;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.domain.enums.Role;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
@@ -46,6 +47,14 @@ public class UserConverter {
                 .email(user.getEmail())
                 .nickName(user.getName())
                 .profileImg(user.getProfileImage())
+                .build();
+    }
+
+    public static ExistedEmail toExistedEmailResult (String email, String resetToken, User user) {
+        return ExistedEmail.builder()
+                .existingEmail(email)
+                .resetToken(resetToken)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/com/main/writeRoom/domain/User/ExistedEmail.java
+++ b/src/main/java/com/main/writeRoom/domain/User/ExistedEmail.java
@@ -1,0 +1,31 @@
+package com.main.writeRoom.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "ExistedEmail")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExistedEmail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String resetToken;
+    private String existingEmail;
+    @ManyToOne
+    @JoinColumn(name = "user")
+    private User user;
+}

--- a/src/main/java/com/main/writeRoom/domain/User/User.java
+++ b/src/main/java/com/main/writeRoom/domain/User/User.java
@@ -4,6 +4,7 @@ import com.main.writeRoom.common.BaseEntity;
 import com.main.writeRoom.domain.enums.Role;
 import com.main.writeRoom.domain.mapping.RoomParticipation;
 import com.main.writeRoom.oauth.domain.OAuthProvider;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,6 +41,8 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<RoomParticipation> roomParticipationList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExistedEmail> existedEmails = new ArrayList<>();
 
     public User setProfile(String nickName, String userImg) {
         this.name = nickName != null ? nickName : name;

--- a/src/main/java/com/main/writeRoom/repository/ExistedEmailRespository.java
+++ b/src/main/java/com/main/writeRoom/repository/ExistedEmailRespository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExistedEmailRespository extends JpaRepository<ExistedEmail, Long> {
+    ExistedEmail findByResetToken(String resetToken);
 }

--- a/src/main/java/com/main/writeRoom/repository/ExistedEmailRespository.java
+++ b/src/main/java/com/main/writeRoom/repository/ExistedEmailRespository.java
@@ -1,0 +1,9 @@
+package com.main.writeRoom.repository;
+
+import com.main.writeRoom.domain.User.ExistedEmail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExistedEmailRespository extends JpaRepository<ExistedEmail, Long> {
+}

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthService.java
@@ -9,7 +9,7 @@ public interface AuthService {
     UserResponseDTO.UserSignInResult login(UserRequestDTO.UserSignIn request);
     User join(UserRequestDTO.UserSignUp request);
     User sendResetPwd(UserRequestDTO.ResetPasswordForEmail request) throws MessagingException;
-    User resetPwd(UserRequestDTO.ResetPassword request, String resetToken);
+    User resetPwd(UserRequestDTO.ResetPassword request, String resetToken, String type);
 
     //UserResponseDTO.UserSignInResult kakaoLogin(String code);
 }

--- a/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/AuthService/AuthServiceImpl.java
@@ -68,7 +68,7 @@ public class AuthServiceImpl implements AuthService{
 
         String resetToken = UUID.randomUUID().toString();
         user.setResetToken(resetToken);
-        emailService.sendEmail(request.getEmail(), user, resetToken);
+        emailService.sendEmail(request.getEmail(), user, resetToken, "password");
         return user;
     }
 

--- a/src/main/java/com/main/writeRoom/service/MailService/EmailService.java
+++ b/src/main/java/com/main/writeRoom/service/MailService/EmailService.java
@@ -4,6 +4,7 @@ import com.main.writeRoom.domain.User.User;
 import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -16,7 +17,7 @@ public class EmailService {
     @Value("${spring.mail.username}") String mail;
 
 
-    public MimeMessage createUpdatedEmailForm(String email, User user, String resetToken) throws MessagingException, UnsupportedJwtException {
+    public MimeMessage ResetPwdEmailForm(String email, User user, String resetToken) throws MessagingException, UnsupportedJwtException {
         MimeMessage message = emailSender.createMimeMessage();
 
         message.addRecipients(MimeMessage.RecipientType.TO, email);
@@ -27,7 +28,7 @@ public class EmailService {
         msgOfEmail += "<p>본 이메일을 통해 writeRoom 계정의 비밀번호를 재설정할 수 있습니다.<p>";
         msgOfEmail += "<p>아래 링크를 클릭하면 비밀번호 재설정 페이지로 이동합니다.<p>";
         msgOfEmail += "<br>";
-        msgOfEmail += "<a href='http://localhost:3000/myprofile/account/pw/?token=" + resetToken+ "'>비밀번호 재설정으로 이동</a>";
+        msgOfEmail += "<a href='http://localhost:3000/reset/pw/currentEmail?token=" + resetToken+ "'>비밀번호 재설정으로 이동</a>";
         msgOfEmail += "<br>";
         msgOfEmail += "<br>";
         msgOfEmail += "<p>비밀번호 재설정을 통해 비밀번호가 변경되면 계정 보안을 위해 모든 기기와 브라우저에서 자동 로그인이 해제됩니다.";
@@ -37,9 +38,37 @@ public class EmailService {
         return message;
     }
 
-    public User sendEmail(String email, User user, String resetToken) throws MessagingException, UnsupportedJwtException {
-        MimeMessage emailForm = createUpdatedEmailForm(email, user, resetToken);
-        emailSender.send(emailForm);
+    public MimeMessage ResetEmailForm(String email, User user, String resetToken) throws MessagingException, UnsupportedJwtException {
+        MimeMessage message = emailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+        message.setSubject("WriteRoom 이메일 변경 안내 메일입니다.");
+        String msgOfEmail="";
+        msgOfEmail += "<p>안녕하세요. <p>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<p>방금 회원님의 Writeroom 계정 이메일 주소를 <p>";
+        msgOfEmail += user.getEmail() + "에서" + email + "(으)로 변경했습니다.<p>";
+        msgOfEmail += "<p>회원님이 연결한 게 맞다면 이메일을 무시해도 됩니다. 아무런 조치를 취할 필요가 없습니다.<p>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<b>본인이 아닌 경우: </b>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "누군가 회원님의 Writeroom 계정에 액세스했을 수 있습니다. 계정 보호를 위해 비밀번호 재설정이 필요합니다.";
+        msgOfEmail += "<a href='http://localhost:3000/reset/pw/newEmail?token=" + resetToken+ "'>비밀번호 재설정</a>";
+        msgOfEmail += "<br>";
+        msgOfEmail += "<p>Writeroom 팀<p>";
+        message.setFrom(mail);
+        message.setText(msgOfEmail, "utf-8", "html");
+        return message;
+    }
+
+    public User sendEmail(String email, User user, String resetToken, String type) throws MessagingException, UnsupportedJwtException {
+        if (Objects.equals(type, "password")) {
+            MimeMessage resetPwdEmailForm = ResetPwdEmailForm(email, user, resetToken);
+            emailSender.send(resetPwdEmailForm);
+        } else {
+            MimeMessage resetEmailForm = ResetEmailForm(email, user, resetToken);
+            emailSender.send(resetEmailForm);
+        }
         return user;
     }
 }

--- a/src/main/java/com/main/writeRoom/service/UserService/UserCommandService.java
+++ b/src/main/java/com/main/writeRoom/service/UserService/UserCommandService.java
@@ -2,9 +2,11 @@ package com.main.writeRoom.service.UserService;
 
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
+import jakarta.mail.MessagingException;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserCommandService {
     User updatedMyProfile(Long userId, UserRequestDTO.UpdatedMyprofile request, MultipartFile userImg);
     User updatedPassword(Long userId, UserRequestDTO.UpdatedPassword request);
+    User updatedEmail(Long userId, UserRequestDTO.ResetPasswordForEmail request) throws MessagingException;
 }

--- a/src/main/java/com/main/writeRoom/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/UserService/UserCommandServiceImpl.java
@@ -3,10 +3,15 @@ package com.main.writeRoom.service.UserService;
 import com.main.writeRoom.apiPayload.status.ErrorStatus;
 import com.main.writeRoom.aws.s3.AmazonS3Manager;
 import com.main.writeRoom.aws.s3.Uuid;
+import com.main.writeRoom.converter.UserConverter;
+import com.main.writeRoom.domain.User.ExistedEmail;
 import com.main.writeRoom.domain.User.User;
 import com.main.writeRoom.handler.UserHandler;
+import com.main.writeRoom.repository.ExistedEmailRespository;
 import com.main.writeRoom.repository.UuidRepository;
+import com.main.writeRoom.service.MailService.EmailService;
 import com.main.writeRoom.web.dto.user.UserRequestDTO;
+import jakarta.mail.MessagingException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,6 +27,9 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
     private final PasswordEncoder encoder;
+    private final EmailService emailService;
+    private final ExistedEmailRespository existedEmailRespository;
+
 
     @Override
     @Transactional
@@ -48,5 +56,21 @@ public class UserCommandServiceImpl implements UserCommandService {
         }
         String updatedPwd = encoder.encode(request.getUpdatePwd());
         return user.setPassword(updatedPwd);
+    }
+
+    @Transactional
+    public User updatedEmail(Long userId, UserRequestDTO.ResetPasswordForEmail request) throws MessagingException {
+        User user = userQueryService.findUser(userId);
+        String resetToken = UUID.randomUUID().toString();
+
+        user.setResetToken(resetToken);
+
+        emailService.sendEmail(request.getEmail(), user, resetToken, "email");
+        user.setEmail(request.getEmail());
+
+        ExistedEmail existedEmail = UserConverter.toExistedEmailResult(request.getEmail(), resetToken, user);
+        existedEmailRespository.save(existedEmail);
+
+        return user;
     }
 }


### PR DESCRIPTION
## 이슈 
- https://github.com/WRITE-ROOM/SERVER/issues/81

<br> 

## 작업내용
- 로그아웃 상태에서의 비밀번호 재설정, 이메일 변경 시 비밀번호 재설정 분리

<br>

## 참고 사항
- 로그아웃 구현 완료 시 비밀번호 재설정할 때 로그아웃 추가하겠습니당