### PR TITLE
[FIX] 챌린지 달성 카운트 수정 #167

### DIFF
--- a/src/main/java/com/main/writeRoom/controller/ChallengeController.java
+++ b/src/main/java/com/main/writeRoom/controller/ChallengeController.java
@@ -256,8 +256,7 @@ public class ChallengeController {
             throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
         }
         ChallengeGoals goals = goalsParticipation.getChallengeGoals();
-        Integer achieveCount = goalsQueryService.findAchieveNote(user1, goals);
-        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, achieveCount));
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, goalsParticipation));
     }
 
     //다른 참여자꺼 챌린지 목표량 조회
@@ -277,8 +276,11 @@ public class ChallengeController {
     public ApiResponse<ChallengeResponseDTO.ChallengeGoalsDTO> getParticipantsGoals(@PathVariable(name = "participantsId") Long participantsId, @PathVariable(name = "challengeId") Long challengeId) {
         User user1 = userQueryService.findUser(participantsId);
         ChallengeGoals goals = goalsQueryService.findGoals(challengeId);
-        Integer achieveCount = goalsQueryService.findAchieveNote(user1, goals);
-        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, achieveCount));
+        ChallengeGoalsParticipation goalsParticipation = goalsQueryService.findProgressGoalsParticipation(user1, goals.getRoom());
+        if (goalsParticipation == null) {
+            throw new ChallengeHandler(ErrorStatus.PROGRESS_NOTFOUND);
+        }
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toChallengeGoalsDTO(user1, goals, goalsParticipation));
     }
 
     //챌린지 목표량 포기
@@ -380,8 +382,7 @@ public class ChallengeController {
         User user1 = userQueryService.findUser(user);
         ChallengeGoals goals = goalsQueryService.findGoals(challengeId);
         ChallengeGoalsParticipation goalsParticipation = myChallengeQueryService.findByUserAndChallengeGoals(user1, goals);
-        Integer achieveCount = goalsQueryService.findAchieveNote(user1, goals);
-        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toMyChallengeGoalsDTO(user1, goals, achieveCount, goalsParticipation));
+        return ApiResponse.of(SuccessStatus._OK, ChallengeConverter.toMyChallengeGoalsDTO(user1, goals, goalsParticipation));
     }
 
     //챌린지 내역 삭제 - 루틴

--- a/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
+++ b/src/main/java/com/main/writeRoom/converter/ChallengeConverter.java
@@ -108,7 +108,7 @@ public class ChallengeConverter {
     }
 
     //챌린지 목표량 조회
-    public static ChallengeResponseDTO.ChallengeGoalsDTO toChallengeGoalsDTO(User user, ChallengeGoals goals, Integer achieveCount)  {
+    public static ChallengeResponseDTO.ChallengeGoalsDTO toChallengeGoalsDTO(User user, ChallengeGoals goals, ChallengeGoalsParticipation goalsParticipation)  {
         List<ChallengeResponseDTO.UserDTO> userList = goals.getChallengeGoalsParticipationList().stream()
                 .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
@@ -122,7 +122,7 @@ public class ChallengeConverter {
                 .deadline(goals.getDeadline())
                 .targetCount(goals.getTargetCount())
                 .userList(userList)
-                .achieveCount(achieveCount)
+                .achieveCount(goalsParticipation.getAchieveCount())
                 .build();
     }
 
@@ -198,7 +198,7 @@ public class ChallengeConverter {
     }
 
     //나의 챌린지 상세 조회 - 목표량
-    public static ChallengeResponseDTO.MyChallengeGoalsDTO toMyChallengeGoalsDTO(User user, ChallengeGoals goals, Integer achieveCount, ChallengeGoalsParticipation goalsParticipation)  {
+    public static ChallengeResponseDTO.MyChallengeGoalsDTO toMyChallengeGoalsDTO(User user, ChallengeGoals goals, ChallengeGoalsParticipation goalsParticipation)  {
         List<ChallengeResponseDTO.UserDTO> userList = goals.getChallengeGoalsParticipationList().stream()
                 .filter(participation -> participation.getChallengeStatus() != ChallengeStatus.GIVEUP)
                 .map(participation -> {
@@ -212,7 +212,7 @@ public class ChallengeConverter {
                 .deadline(goals.getDeadline())
                 .targetCount(goals.getTargetCount())
                 .userList(userList)
-                .achieveCount(achieveCount)
+                .achieveCount(goalsParticipation.getAchieveCount())
                 .challengeStatus(goalsParticipation.getChallengeStatus())
                 .build();
     }

--- a/src/main/java/com/main/writeRoom/repository/NoteRepository.java
+++ b/src/main/java/com/main/writeRoom/repository/NoteRepository.java
@@ -23,12 +23,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     @Query("select n from Note n where n.createdAt>= :startDate and n.createdAt<= :deadline and n.user = :user and n.room = :room and n.achieve = 'TRUE'")
     List<Note> findAchieveNotes(@Param("startDate") LocalDateTime startDate, @Param("deadline") LocalDateTime deadline, @Param("user") User user, @Param("room") Room room);
 
-    @Query("select count(*) from Note n where n.createdAt>= :startDate and n.createdAt<= :deadline and n.user = :user and n.room = :room and n.achieve = 'TRUE'")
-    Integer findAchieveCount(@Param("startDate") LocalDateTime startDate, @Param("deadline") LocalDateTime deadline, @Param("user") User user, @Param("room") Room room);
-
-    @Query("select count(*) from Note n where n.user = :user and n.room = :room and n.achieve = 'TRUE'")
-    Integer findAchieveCountNoDate(@Param("user") User user, @Param("room") Room room);
-
     Page<Note> findAllByRoom(Room room, PageRequest pageRequest);
     Long countByRoom(Room room);
 

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryService.java
@@ -11,10 +11,6 @@ import java.util.List;
 
 public interface ChallengeGoalsQueryService {
     public ChallengeGoals findGoals(Long challengeId);
-    public Integer findAchieveNote(User user, ChallengeGoals goals);
-
-    public ChallengeGoalsParticipation findGoalsParticipation(User user, ChallengeGoals goals);
-
     public ChallengeGoalsParticipation findProgressGoalsParticipation(User user, Room room);
     public List<ChallengeGoalsParticipation> findByChallengeStatus(ChallengeStatus challengeStatus);
 

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeGoalsQueryServiceImpl.java
@@ -35,19 +35,6 @@ public class ChallengeGoalsQueryServiceImpl implements ChallengeGoalsQueryServic
     }
 
     @Override
-    public Integer findAchieveNote(User user, ChallengeGoals goals) {
-        if (goals.getStartDate() == null) {
-            return noteRepository.findAchieveCountNoDate(user, goals.getRoom());
-        }
-        else return noteRepository.findAchieveCount(goals.getStartDate().atStartOfDay(), goals.getDeadline().atTime(LocalTime.MAX), user,goals.getRoom());
-    }
-
-    @Override
-    public ChallengeGoalsParticipation findGoalsParticipation(User user, ChallengeGoals goals) {
-        return goalsParticipationRepository.findByUserAndChallengeGoals(user, goals);
-    }
-
-    @Override
     public ChallengeGoalsParticipation findProgressGoalsParticipation(User user, Room room) {
         return goalsParticipationRepository.findProgressGoalsParticipation(user, room);
     }

--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
@@ -41,7 +41,7 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
     @Override
     public List<ChallengeResponseDTO.NoteDTO> findNoteDate(User user, ChallengeRoutine routine) { //챌린지 루틴 기간 동안에 '200자 이상' 작성된 노트의 작성 날짜를 조회
         Room room = routine.getRoom();
-        List<Note> noteList = noteRepository.findAchieveNotes(routine.getStartDate().atStartOfDay(), routine.getDeadline().atTime(LocalTime.MAX), user, room);
+        List<Note> noteList = noteRepository.findAchieveNotes(routine.getCreatedAt(), routine.getDeadline().atTime(LocalTime.MAX), user, room);
         List<ChallengeResponseDTO.NoteDTO> noteDTOList = noteList.stream()
                 .map(note -> {
                     return ChallengeConverter.toNoteDTO(note);


### PR DESCRIPTION
### 이슈
- #167 
### 작업내용
챌린지 루틴, 목표량의 달성카운트에서 동일한 날짜에 작성된 챌린지 시작 전의 노트들까지 카운트되는 문제를 수정했습니다.