### PR TITLE
[FIX] 챌린지 루틴 생성 날짜에 따른 노트 조회 수정 #170

### DIFF
--- a/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
+++ b/src/main/java/com/main/writeRoom/service/ChallengeService/ChallengeRoutineQueryServiceImpl.java
@@ -41,7 +41,12 @@ public class ChallengeRoutineQueryServiceImpl implements ChallengeRoutineQuerySe
     @Override
     public List<ChallengeResponseDTO.NoteDTO> findNoteDate(User user, ChallengeRoutine routine) { //챌린지 루틴 기간 동안에 '200자 이상' 작성된 노트의 작성 날짜를 조회
         Room room = routine.getRoom();
-        List<Note> noteList = noteRepository.findAchieveNotes(routine.getCreatedAt(), routine.getDeadline().atTime(LocalTime.MAX), user, room);
+        List<Note> noteList = null;
+        if (routine.getCreatedAt().toLocalDate().isEqual(routine.getStartDate())) {
+            noteList = noteRepository.findAchieveNotes(routine.getCreatedAt(), routine.getDeadline().atTime(LocalTime.MAX), user, room);
+        } else {
+            noteList = noteRepository.findAchieveNotes(routine.getStartDate().atStartOfDay(), routine.getDeadline().atTime(LocalTime.MAX), user, room);
+        }
         List<ChallengeResponseDTO.NoteDTO> noteDTOList = noteList.stream()
                 .map(note -> {
                     return ChallengeConverter.toNoteDTO(note);


### PR DESCRIPTION
### 이슈
- #170 

### 작업내용
- 챌린지 루틴 생성 날짜에 따른 노트 조회 수정